### PR TITLE
Remove single-transaction flag in script

### DIFF
--- a/sql/derived_tables/README.md
+++ b/sql/derived_tables/README.md
@@ -38,7 +38,7 @@ for f in $( cat runlist.txt ); do
     echo >> logfile
     cat $f > tmpfile
     echo "GRANT SELECT ON ALL TABLES IN SCHEMA folio_reporting TO ldp;" >> tmpfile
-    psql ldp -U ldpreport -a -1 -f tmpfile >> logfile 2>&1
+    psql ldp -U ldpreport -a -f tmpfile >> logfile 2>&1
 done
 ```
 


### PR DESCRIPTION
Running a derived table query file in a transaction causes the drop
table statement to be rolled back if an error occurs while creating
the new table.  Allowing the drop table to be committed in such cases
is preferable to the possibility that users might query an old version
of the table without realizing it.  For this reason the example script
has been changed to run the SQL in autocommit mode.