### PR TITLE
Created agreement cost and count queries for 2G

### DIFF
--- a/sql_2g/derived_tables/agreements_erm_resource.sql
+++ b/sql_2g/derived_tables/agreements_erm_resource.sql
@@ -7,18 +7,22 @@ DROP TABLE IF EXISTS folio_reporting.agreements_erm_resource;
 CREATE TABLE folio_reporting.agreements_erm_resource AS
 SELECT
     id AS res_id,
+    res_name,
     res_sub_type_fk,
     rst.rdv_value AS res_sub_type_fk_value,
     rst.rdv_label AS res_sub_type_fk_label,
-    res_name,
     res_type_fk,
     rt.rdv_value AS res_type_fk_value,
-    rt.rdv_label AS res_type_fk_label
+    rt.rdv_label AS res_type_fk_label,
+    res_publication_type_fk,
+    rpub.rdv_value AS res_publication_type_fk_value,
+    rpub.rdv_label AS res_publication_type_fk_label
 FROM
     folio_agreements.erm_resource AS res
     INNER JOIN folio_agreements.entitlement AS ent ON res.id = ent.ent_resource_fk
     LEFT JOIN folio_agreements.refdata_value AS rst ON res.res_sub_type_fk = rst.rdv_id
-    LEFT JOIN folio_agreements.refdata_value AS rt ON res.res_type_fk = rt.rdv_id;
+    LEFT JOIN folio_agreements.refdata_value AS rt ON res.res_type_fk = rt.rdv_id
+   	LEFT JOIN folio_agreements.refdata_value AS rpub ON res.res_publication_type_fk = rpub.rdv_id;
 
 CREATE INDEX ON folio_reporting.agreements_erm_resource (res_id);
 
@@ -35,4 +39,10 @@ CREATE INDEX ON folio_reporting.agreements_erm_resource (res_type_fk);
 CREATE INDEX ON folio_reporting.agreements_erm_resource (res_type_fk_value);
 
 CREATE INDEX ON folio_reporting.agreements_erm_resource (res_type_fk_label);
+
+CREATE INDEX ON folio_reporting.agreements_erm_resource (res_publication_type_fk);
+
+CREATE INDEX ON folio_reporting.agreements_erm_resource (res_publication_type_fk_value);
+
+CREATE INDEX ON folio_reporting.agreements_erm_resource (res_publication_type_fk_label);
 

--- a/sql_2g/derived_tables/agreements_subscription_agreement_entitlement.sql
+++ b/sql_2g/derived_tables/agreements_subscription_agreement_entitlement.sql
@@ -5,10 +5,14 @@ DROP TABLE IF EXISTS folio_reporting.agreements_subscription_agreement_entitleme
 CREATE TABLE folio_reporting.agreements_subscription_agreement_entitlement AS
 SELECT
     sa_id AS subscription_agreement_id,
-    sa_agreement_type AS subscription_agreement_type,
     sa_name AS subscription_agreement_name,
     sa_local_reference AS subscription_agreement_local_reference,
-    sa_agreement_status AS subscription_agreement_agreement_status,
+    sa_agreement_type AS subscription_agreement_type,
+    sat.rdv_value AS subscription_agreement_type_value,
+    sat.rdv_label AS subscription_agreement_type_label,
+    sa_agreement_status AS subscription_agreement_status,
+    sas.rdv_value AS subscription_agreement_status_value,
+    sas.rdv_label AS subscription_agreement_status_label,
     ent.ent_id AS entitlement_id,
     ent.ent_active_to AS entitlement_active_to,
     ent.ent_active_from AS entitlement_active_from,
@@ -20,17 +24,27 @@ SELECT
 FROM
     folio_agreements.subscription_agreement AS sa
     LEFT JOIN folio_agreements.entitlement AS ent ON sa.sa_id = ent.ent_owner_fk
-    LEFT JOIN folio_agreements.order_line AS ol ON ent.ent_id = ol.pol_owner_fk;
+    LEFT JOIN folio_agreements.order_line AS ol ON ent.ent_id = ol.pol_owner_fk
+   	LEFT JOIN folio_agreements.refdata_value AS sat ON sa_agreement_type = sat.rdv_id
+    LEFT JOIN folio_agreements.refdata_value AS sas ON sa_agreement_status = sas.rdv_id;
 
 CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_id);
-
-CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_type);
 
 CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_name);
 
 CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_local_reference);
 
-CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_agreement_status);
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_type);
+
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_type_value);
+
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_type_label);
+
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_status);
+
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_status_value);
+
+CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (subscription_agreement_status_label);
 
 CREATE INDEX ON folio_reporting.agreements_subscription_agreement_entitlement (entitlement_id);
 

--- a/sql_2g/report_queries/erm/README.md
+++ b/sql_2g/report_queries/erm/README.md
@@ -1,0 +1,9 @@
+# ERM Reports
+
+These queries provides several reports that suites different needs on reporting on
+Electronic Resource Management. This will be extended as the needs of reporting and
+the available data sources grows. 
+
+* [Costs](./costs)
+
+* [Counts](./counts)

--- a/sql_2g/report_queries/erm/costs/README.md
+++ b/sql_2g/report_queries/erm/costs/README.md
@@ -1,0 +1,26 @@
+# ERM Agreements Cost Report
+
+## Purpose
+
+This report is to provide a dataset of invoice lines to summarize costs by agreements. Filters were designed to customize this queries on local needs.
+
+## Parameters
+
+The parameters in the table below can be set in the WITH clause to filter the report output.
+
+| parameter | description | examples |
+| --- | --- | --- |
+| agreement_status | date invoice was approved | 'Active', 'Closed' etc. |
+| resource_type | type of resource | 'monograph', 'serial' etc. |
+| resource_sub_type | subtype of resource | 'electronic', 'print' etc. |
+| resource_publication_type | publication type of resource | 'journal', 'book'  etc. |
+| po_line_order_format | given order format | 'Electronic Resource', 'Physical Resource', 'P/E Mix' etc. |
+| invoice_line_status | status of invoice | 'Paid' or 'Approved' etc. |
+| invoice_payment_date | date invoice was paid | Set start\_date and end\_date in YYYY-MM-DD format. |
+
+## Sample Output
+
+|subscription_agreement_name|subscription_agreement_status|entitlement_id|entitlement_active_from|entitlement_active_to|erm_resource_name|erm_resource_type|erm_resource_sub_type|erm_resource_publication_type|po_line_payment_status|po_line_is_package|po_line_order_format|invl_status|invoice_payment_date|invl_sub_total|invl_total|transactions_invl_total|
+|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|----------|
+|Agreement_Test_PCI |Active|934cd3cd-2a0f-476e-a740-51796bb1a480|||De Gruyter : Journal Package Mathematics, Physics, Engineering : 2019-07-08||||Fully Paid|true|Electronic Resource|Open||6300|6300||
+|Agreement_Test_Package 2|Active|934cd3cd-2a0f-476e-a740-51796bb1a480|||BMJ Publishing Group : BMJ Journals Online Archive : NL||||Fully Paid|true|Electronic Resource|Paid||9000|9000|$9,000.00|

--- a/sql_2g/report_queries/erm/costs/erm_agreement_cost.sql
+++ b/sql_2g/report_queries/erm/costs/erm_agreement_cost.sql
@@ -1,0 +1,111 @@
+/** Documentation of ERM AGREEMENT COST QUERY
+
+DERIVED TABLES
+agreements_subscription_agreement_entitlement
+agreements_erm_resource
+finance_transaction_invoices
+
+TABLES
+folio_orders.po_line
+folio_invoice.invoice_lines
+folio_invoice.invoices 
+
+FILTERS: FOR USERS TO SELECT
+agreement_status, resource_type, resource_sub_type, resource_publication_type, po_line_order_format, invoice_line_status, payment_date
+
+ */
+WITH parameters AS (
+    SELECT
+    
+		-- filters on agreement level
+		''::VARCHAR AS agreement_status, -- Enter your subscription agreement status eg. 'Active', 'Closed' etc.
+		-- filters on erm_resource level
+		''::VARCHAR AS resource_type, -- Enter your erm resource type eg. 'monograph', 'serial' etc.
+		''::VARCHAR AS resource_sub_type, -- Enter your erm resource type eg. 'electronic', 'print' etc.
+		''::VARCHAR AS resource_publication_type, -- Enter your publication type eg. 'journal', 'book'  etc.
+        -- filters on purchase order line level
+        ''::VARCHAR AS po_line_order_format, -- Enter your po line format eg. 'Electronic Resource', 'Physical Resource', 'P/E Mix' etc.
+        -- filters on invoice line level
+        ''::VARCHAR AS invoice_line_status, -- Enter your invoice line status eg. 'Paid' or 'Approved'etc.
+        -- filters on invoice level
+        -- Please comment/uncomment one pair the these parameters if you want to define the date range of paid invoices
+        NULL::DATE AS start_date,
+        NULL::DATE AS end_date
+        --'2021-01-01' :: DATE AS start_date, -- start date day is included in interval
+        --'2022-01-01' :: DATE AS end_date, -- end date day is NOT included in interval -> enter next day
+
+),
+     invoice_detail AS (
+         SELECT
+             inv.id AS "invoice_id",
+             json_extract_path_text(inv.jsonb, 'paymentDate')::date AS "invoice_payment_date"
+         FROM
+             folio_invoice.invoices AS inv
+     )
+SELECT
+	sa_ent_dt.subscription_agreement_name,
+	sa_ent_dt.subscription_agreement_status_label AS subscription_agreement_status,
+	sa_ent_dt.entitlement_id,
+	sa_ent_dt.entitlement_active_from,
+	sa_ent_dt.entitlement_active_to,
+	erm_resource.res_name AS erm_resource_name,
+	erm_resource.res_type_fk_label AS erm_resource_type,
+	erm_resource.res_sub_type_fk_label AS erm_resource_sub_type,
+	erm_resource.res_publication_type_fk_label AS erm_resource_publication_type,
+    json_extract_path_text(pol.jsonb, 'paymentStatus') AS "po_line_payment_status",
+    json_extract_path_text(pol.jsonb, 'isPackage') AS "po_line_is_package",	
+    json_extract_path_text(pol.jsonb, 'orderFormat') AS "po_line_order_format",   
+    json_extract_path_text(invl.jsonb, 'invoiceLineStatus') AS "invl_status",
+    inv.invoice_payment_date AS "invoice_payment_date",
+    json_extract_path_text(invl.jsonb, 'subTotal') AS "invl_sub_total", -- this are costs by invoice_line in invoice currency
+    json_extract_path_text(invl.jsonb, 'total') AS "invl_total", -- this are costs by invoice_line in invoice currency
+    cast(fintrainvl.transaction_amount AS money) AS "transactions_invl_total"  
+FROM
+	folio_reporting.agreements_subscription_agreement_entitlement AS sa_ent_dt
+		LEFT JOIN folio_reporting.agreements_erm_resource AS erm_resource ON erm_resource.res_id = sa_ent_dt.entitlement_resource_fk
+		LEFT JOIN folio_orders.po_line AS pol ON pol.id = sa_ent_dt.po_line_id
+		LEFT JOIN folio_invoice.invoice_lines AS invl ON json_extract_path_text(invl.jsonb, 'poLineId') = pol.id
+        LEFT JOIN invoice_detail AS inv ON json_extract_path_text(invl.jsonb, 'invoiceId') = inv.invoice_id
+        LEFT JOIN folio_reporting.finance_transaction_invoices AS fintrainvl ON fintrainvl.invoice_line_id = invl.id
+WHERE	
+	((sa_ent_dt.subscription_agreement_status_label = (SELECT agreement_status FROM parameters)) OR 
+		((SELECT agreement_status FROM parameters) = ''))
+	AND 	
+	((erm_resource.res_type_fk_label = (SELECT resource_type FROM parameters)) OR 
+		((SELECT resource_type FROM parameters) = ''))
+	AND 	
+	((erm_resource.res_sub_type_fk_label = (SELECT resource_sub_type FROM parameters)) OR 
+		((SELECT resource_sub_type FROM parameters) = ''))
+	AND 	
+	((erm_resource.res_publication_type_fk_label = (SELECT resource_publication_type FROM parameters)) OR 
+		((SELECT resource_publication_type FROM parameters) = ''))
+	AND 	
+	((json_extract_path_text(invl.jsonb, 'invoiceLineStatus') = (SELECT invoice_line_status FROM parameters)) OR 
+		((SELECT invoice_line_status FROM parameters) = ''))
+	AND 	
+	((json_extract_path_text(pol.jsonb, 'orderFormat') = (SELECT po_line_order_format FROM parameters)) OR 
+		((SELECT po_line_order_format FROM parameters) = ''))
+	AND
+    ((inv.invoice_payment_date >= (SELECT start_date FROM parameters) AND
+		inv.invoice_payment_date < (SELECT end_date FROM parameters))
+		OR 
+		(((SELECT start_date FROM parameters) IS NULL) 
+			OR ((SELECT end_date FROM parameters) IS NULL)))	
+GROUP BY 
+	sa_ent_dt.subscription_agreement_name,
+	sa_ent_dt.subscription_agreement_status_label,
+	sa_ent_dt.entitlement_id,
+	sa_ent_dt.entitlement_active_from,
+	sa_ent_dt.entitlement_active_to,
+	erm_resource.res_name,
+	erm_resource.res_type_fk_label,
+	erm_resource.res_sub_type_fk_label,
+	erm_resource.res_publication_type_fk_label,
+	json_extract_path_text(pol.jsonb, 'paymentStatus'),
+	json_extract_path_text(pol.jsonb, 'orderFormat'),
+	json_extract_path_text(invl.jsonb, 'invoiceLineStatus'),
+	json_extract_path_text(pol.jsonb, 'isPackage'),
+	inv.invoice_payment_date,
+    json_extract_path_text(invl.jsonb, 'subTotal'),
+    json_extract_path_text(invl.jsonb, 'total'),
+	fintrainvl.transaction_amount;

--- a/sql_2g/report_queries/erm/count/README.md
+++ b/sql_2g/report_queries/erm/count/README.md
@@ -1,0 +1,15 @@
+# ERM Agreements Count Report
+
+## Purpose
+
+This report is to counts of e-resources by agreement
+
+## Future Updates
+More data field as resourcs types and dates for dispülay and filtering will be included in next updates  
+
+## Sample Output
+
+|Agreements|Status|Count|
+|----------|----------|----------|
+|Agreement_Test_PCI |Active|44|
+|Agreement_Test_Package 2|Active|30|

--- a/sql_2g/report_queries/erm/count/README.md
+++ b/sql_2g/report_queries/erm/count/README.md
@@ -4,8 +4,20 @@
 
 This report is to counts of e-resources by agreement
 
+## Parameters
+
+The parameters in the table below can be set in the WITH clause to filter the report output.
+
+| parameter | description | examples |
+| --- | --- | --- |
+| agreement_status | date invoice was approved | 'Active', 'Closed' etc. |
+| ent_start_date | start date of period with active entitlements | Set start\_date and end\_date in YYYY-MM-DD format. |
+| ent_ended_date | end date of period with active entitlements | Set start\_date and end\_date in YYYY-MM-DD format. |
+| pci_start_date | start date of period with accessible package content items | Set start\_date and end\_date in YYYY-MM-DD format. |
+| pci_end_date |  end date of period with accessible package content items | Set start\_date and end\_date in YYYY-MM-DD format. |
+
 ## Future Updates
-More data field as resourcs types and dates for dispülay and filtering will be included in next updates  
+More data fields as resource type and subscription agreement date for display/filtering will be included in next updates  
 
 ## Sample Output
 

--- a/sql_2g/report_queries/erm/count/erm_agreement_count.sql
+++ b/sql_2g/report_queries/erm/count/erm_agreement_count.sql
@@ -28,7 +28,7 @@ WITH parameters AS (
         --'2022-01-01' :: DATE AS ent_end_date, -- end date day is NOT included in interval -> enter next day	
 		-- filters on package content item level
         NULL::DATE AS pci_start_date,
-        NULL::DATE AS pci_end_date,
+        NULL::DATE AS pci_end_date
         --'2021-01-01' :: DATE AS pci_start_date, -- start date day is included in interval
         --'2022-01-01' :: DATE AS pci_end_date, -- end date day is NOT included in interval -> enter next day		
 )

--- a/sql_2g/report_queries/erm/count/erm_agreement_count.sql
+++ b/sql_2g/report_queries/erm/count/erm_agreement_count.sql
@@ -8,6 +8,31 @@ TABLES
 folio_agreements.refdata_value 
 
 */
+
+WITH parameters AS (
+    SELECT
+    
+		-- filters on agreement level
+		''::VARCHAR AS agreement_status, -- Enter your subscription agreement status eg. 'Active', 'Closed' etc.
+		-- subscription agreement time period will be added when available (IRIS)
+		--NULL::DATE AS a_start_date,
+        --NULL::DATE AS a_end_date,
+        --'2021-01-01' :: DATE AS sa_start_date, -- start date day is included in interval
+        --'2022-01-01' :: DATE AS sa_end_date, -- end date day is NOT included in interval -> enter next day		
+		-- filters on erm_resource level
+		''::VARCHAR AS resource_type, -- Enter your erm resource type eg. 'monograph', 'serial' etc.
+		-- filters on entitelment level
+        NULL::DATE AS ent_start_date,
+        NULL::DATE AS ent_end_date,
+        --'2021-01-01' :: DATE AS ent_start_date, -- start date day is included in interval
+        --'2022-01-01' :: DATE AS ent_end_date, -- end date day is NOT included in interval -> enter next day	
+		-- filters on package content item level
+        NULL::DATE AS pci_start_date,
+        NULL::DATE AS pci_end_date,
+        --'2021-01-01' :: DATE AS pci_start_date, -- start date day is included in interval
+        --'2022-01-01' :: DATE AS pci_end_date, -- end date day is NOT included in interval -> enter next day		
+)
+
 SELECT
     sa_ent.subscription_agreement_name AS "Agreements",
     agrestat.rdv_label AS "Status",
@@ -15,9 +40,35 @@ SELECT
 FROM
     folio_reporting.agreements_package_content_item AS pci_list
     LEFT JOIN folio_reporting.agreements_subscription_agreement_entitlement AS sa_ent ON pci_list.entitlement_id = sa_ent.entitlement_id
-    LEFT JOIN folio_agreements.refdata_value AS agrestat ON agrestat.rdv_id = sa_ent.subscription_agreement_agreement_status
+    LEFT JOIN folio_agreements.refdata_value AS agrestat ON agrestat.rdv_id = sa_ent.subscription_agreement_status
+
+WHERE 
+	((agrestat.rdv_label = (SELECT agreement_status FROM parameters)) OR 
+		((SELECT agreement_status FROM parameters) = ''))
+	AND 			
+    ((pci_list.pci_access_start < (SELECT pci_end_date FROM parameters) AND
+	    (pci_list.pci_access_end >= (SELECT pci_start_date FROM parameters) OR pci_list.pci_access_end IS NULL))
+	    OR 
+		(((SELECT pci_start_date FROM parameters) IS NULL) 
+			OR ((SELECT pci_end_date FROM parameters) IS NULL)))
+	AND 			
+    ((sa_ent.entitlement_active_from < (SELECT ent_end_date FROM parameters) AND
+	    (sa_ent.entitlement_active_to >= (SELECT ent_start_date FROM parameters) OR sa_ent.entitlement_active_to IS NULL))
+	    OR 
+		(((SELECT ent_start_date FROM parameters) IS NULL) 
+			OR ((SELECT ent_end_date FROM parameters) IS NULL)))	
+	-- subscription agreement time period will be added when available (IRIS)
+	/*		
+	AND 			
+    ((sa_ent.sa_start_date < (SELECT a_end_date FROM parameters) AND
+	    (sa_ent.sa_end_date >= (SELECT a_start_date FROM parameters) OR sa_ent.sa_end_date IS NULL))
+	    OR 
+		(((SELECT a_start_date FROM parameters) IS NULL) 
+			OR ((SELECT a_end_date FROM parameters) IS NULL)))	
+	*/
 GROUP BY
     sa_ent.subscription_agreement_name,
-    agrestat.rdv_label;
+    agrestat.rdv_label
+    ;
 
 

--- a/sql_2g/report_queries/erm/count/erm_agreement_count.sql
+++ b/sql_2g/report_queries/erm/count/erm_agreement_count.sql
@@ -1,0 +1,23 @@
+/** Documentation of ERM AGREEMENT COUNT QUERY
+
+DERIVED TABLES
+agreements_package_content_item
+agreements_subscription_agreement_entitlement
+
+TABLES
+folio_agreements.refdata_value 
+
+*/
+SELECT
+    sa_ent.subscription_agreement_name AS "Agreements",
+    agrestat.rdv_label AS "Status",
+    count(DISTINCT pci_list.pci_id) AS "Count"
+FROM
+    folio_reporting.agreements_package_content_item AS pci_list
+    LEFT JOIN folio_reporting.agreements_subscription_agreement_entitlement AS sa_ent ON pci_list.entitlement_id = sa_ent.entitlement_id
+    LEFT JOIN folio_agreements.refdata_value AS agrestat ON agrestat.rdv_id = sa_ent.subscription_agreement_agreement_status
+GROUP BY
+    sa_ent.subscription_agreement_name,
+    agrestat.rdv_label;
+
+


### PR DESCRIPTION
Adresses #282 and #283

Can only be tested against `reports_dev` 
Be aware that two derived tables have updates in this PR too and can be exchanged in `erm_agreement_count.sql` by `axeldoerrer_agreements_erm_resource`  and `axeldoerrer_agreements_subscription_agreement_entitlement ` in order to run it.