### PR TITLE
item-related exceptions report

### DIFF
--- a/sql/report_queries/item_related_exceptions/README.md
+++ b/sql/report_queries/item_related_exceptions/README.md
@@ -1,0 +1,28 @@
+# Item-Related Exceptions Report
+
+## Purpose of report
+
+This report shows a list of exceptions, which are actions taken by an operator (staff member) and are recorded in the circulation log. 
+An example is when an item has been manually discharged or discharged by an operator. 
+
+Data fields included are: Date range, location of action, description of action, the loan id on which the action was performed, item details (item id, barcode, and title),
+patron name and email, patron group type, and operator id.
+
+## Sample output
+
+This report generates data with the following format:
+
+|date\_range|action\_date|action|action\_description|action\_result|action\_source|service\_point\_id|user\_id|fee\_fine\_id|item\_id|loan\_id|item\_barcode|patron\_group\_name|patron\_last\_name|patron\_first\_name|patron\_middle\_name|patron\_email|location\_name|service\_point\_display\_name|
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+|2000-01-01 to 2022-01-01|2021-04-14 09:37:16.693-04|Paid fully|Fee/Fine type: Misc Fee. Amount: 2.00. Balance: 0.00. Payment method: cash. Additional information to staff: . Additional information to patron: .|Fee/Fine|ADMINISTRATOR, DIKU|7c5abc9f-f3d7-4856-b8d7-6712462ca007|67a248eb-b259-4e7f-98d0-9b57abd1ef59|2eb2fb7c-74d2-4166-8d97-7a19379a13e1||||Graduate Student|Melnyk|Anna||anna_melnyk@epam.com|||
+|2000-01-01 to 2022-01-01|2021-04-14 12:01:23.681-04|Billed|Fee/Fine type: Lost item fee. Fee/Fine owner: Anna. Amount: 5.00. automated|Fee/Fine|System||9f8c6765-db3f-4a7a-92f6-4c976b51bfdb|4279f19d-4c05-4585-bbed-0c4d14019dab|7212ba6a-8dcf-45a1-be9a-ffaa847c4423|abc46827-c595-4be3-a06e-52928bb6b447|10101|Faculty Member|Barannyk|Roman||roman_barannyk@epam.com|||
+|2000-01-01 to 2022-01-01|2021-04-14 08:53:29.462-04|Created|Type: Page.|Request|Barannyk, Roman|3a40852d-49fd-4df2-a1f9-6e2641a6e91f|9f8c6765-db3f-4a7a-92f6-4c976b51bfdb||7212ba6a-8dcf-45a1-be9a-ffaa847c4423||10101|Faculty Member|Barannyk|Roman||roman_barannyk@epam.com|Annex|Circulation Desk -- Hallway|
+
+
+## Query instructions
+
+The report can be filtered on a date range, type of actions, and location where the action took place.
+(There is a long list of actions: see [documentation for circulation logs interface](https://s3.amazonaws.com/foliodocs/api/mod-audit/p/circulation-logs.html)).
+
+NOTE: This report includes patron personal information and operator identifying ID information, which is not GDPR-compliant. This is needed to identify whether the same 
+patron has received an excessive number of fee or other waivers on items, and which operator is responsible for the actions.

--- a/sql/report_queries/item_related_exceptions/item_related_exceptions.sql
+++ b/sql/report_queries/item_related_exceptions/item_related_exceptions.sql
@@ -1,0 +1,72 @@
+WITH parameters AS (
+    SELECT
+        /* Choose a start and end date for the request period */
+        '2000-01-01'::date AS start_date,
+        '2022-01-01'::date AS end_date,
+        /* Fill in a location name, or leave blank */
+        ''::varchar AS action_location_filter, 
+        /* Fill in 1-4 action names, or leave all blank for all actions */
+        ''::varchar AS action_filter1,-- see list of actions in README documentation 
+        ''::varchar AS action_filter2, -- other action to also include
+        ''::varchar AS action_filter3, -- other action to also include
+        ''::varchar AS action_filter4 -- other action to also include
+),
+items_array AS (
+    SELECT
+        ac.id AS log_id,
+        json_extract_path_text(items.data, 'itemId') AS item_id,
+        json_extract_path_text(items.data, 'loanId') AS loan_id,
+        json_extract_path_text(items.data, 'itemBarcode') AS item_barcode
+    FROM
+        public.audit_circulation_logs AS ac
+        CROSS JOIN json_array_elements(json_extract_path(data, 'items')) AS items (data)
+)
+SELECT
+    (SELECT start_date::varchar FROM parameters) || 
+        ' to ' || 
+        (SELECT end_date::varchar FROM parameters) AS date_range,
+        ac.date AS action_date,
+        ac.action AS action,
+        ac.description AS action_description,
+        ac.object AS action_result,
+        ac.source AS action_source, 
+        ac.service_point_id AS service_point_id,
+        json_extract_path_text(ac.data, 'linkToIds', 'userId') AS user_id,
+        json_extract_path_text(ac.data, 'linkToIds', 'feeFineId') AS fee_fine_id,
+        ia.item_id,
+        ia.loan_id,
+        ia.item_barcode,
+        ug.group_description AS patron_group_name,
+        ug.user_last_name AS patron_last_name,
+        ug.user_first_name AS patron_first_name,
+        ug.user_middle_name AS patron_middle_name,
+        ug.user_email AS patron_email,
+        lsp.location_name AS location_name,
+        lsp.service_point_discovery_display_name AS service_point_display_name
+  FROM public.audit_circulation_logs AS ac
+  LEFT JOIN items_array AS ia
+    ON ac.id=ia.log_id
+  LEFT JOIN folio_reporting.users_groups AS ug
+    ON json_extract_path_text(ac.data, 'linkToIds','userId') = ug.user_id
+  LEFT JOIN folio_reporting.locations_service_points AS lsp
+    ON ac.service_point_id = lsp.service_point_id
+ WHERE
+    ac.date >= (SELECT start_date FROM parameters)
+    AND ac.date < (SELECT end_date FROM parameters)
+    AND (
+        lsp.location_name = (SELECT action_location_filter FROM parameters)
+        OR '' = (SELECT action_location_filter FROM parameters)
+    )
+    AND (
+        ac.action IN ((SELECT action_filter1 FROM parameters),
+                      (SELECT action_filter2 FROM parameters),
+                      (SELECT action_filter3 FROM parameters),
+                      (SELECT action_filter4 FROM parameters)
+                    )
+        OR ('' = (SELECT action_filter1 FROM parameters) AND
+            '' = (SELECT action_filter2 FROM parameters) AND
+            '' = (SELECT action_filter3 FROM parameters) AND
+            '' = (SELECT action_filter4 FROM parameters)
+            )
+    )     
+;   

--- a/sql/report_queries/item_related_exceptions/item_related_exceptions.sql
+++ b/sql/report_queries/item_related_exceptions/item_related_exceptions.sql
@@ -4,9 +4,9 @@ WITH parameters AS (
         '2000-01-01'::date AS start_date,
         '2022-01-01'::date AS end_date,
         /* Fill in a location name, or leave blank */
-        ''::varchar AS action_location_filter, 
+        ''::varchar AS action_location_filter,
         /* Fill in 1-4 action names, or leave all blank for all actions */
-        ''::varchar AS action_filter1,-- see list of actions in README documentation 
+        ''::varchar AS action_filter1, -- see list of actions in README documentation 
         ''::varchar AS action_filter2, -- other action to also include
         ''::varchar AS action_filter3, -- other action to also include
         ''::varchar AS action_filter4 -- other action to also include
@@ -25,32 +25,30 @@ SELECT
     (SELECT start_date::varchar FROM parameters) || 
         ' to ' || 
         (SELECT end_date::varchar FROM parameters) AS date_range,
-        ac.date AS action_date,
-        ac.action AS action,
-        ac.description AS action_description,
-        ac.object AS action_result,
-        ac.source AS action_source, 
-        ac.service_point_id AS service_point_id,
-        json_extract_path_text(ac.data, 'linkToIds', 'userId') AS user_id,
-        json_extract_path_text(ac.data, 'linkToIds', 'feeFineId') AS fee_fine_id,
-        ia.item_id,
-        ia.loan_id,
-        ia.item_barcode,
-        ug.group_description AS patron_group_name,
-        ug.user_last_name AS patron_last_name,
-        ug.user_first_name AS patron_first_name,
-        ug.user_middle_name AS patron_middle_name,
-        ug.user_email AS patron_email,
-        lsp.location_name AS location_name,
-        lsp.service_point_discovery_display_name AS service_point_display_name
-  FROM public.audit_circulation_logs AS ac
-  LEFT JOIN items_array AS ia
-    ON ac.id=ia.log_id
-  LEFT JOIN folio_reporting.users_groups AS ug
-    ON json_extract_path_text(ac.data, 'linkToIds','userId') = ug.user_id
-  LEFT JOIN folio_reporting.locations_service_points AS lsp
-    ON ac.service_point_id = lsp.service_point_id
- WHERE
+    ac.date AS action_date,
+    ac.action AS action,
+    ac.description AS action_description,
+    ac.object AS action_result,
+    ac.source AS action_source,
+    ac.service_point_id AS service_point_id,
+    json_extract_path_text(ac.data, 'linkToIds', 'userId') AS user_id,
+    json_extract_path_text(ac.data, 'linkToIds', 'feeFineId') AS fee_fine_id,
+    ia.item_id,
+    ia.loan_id,
+    ia.item_barcode,
+    ug.group_description AS patron_group_name,
+    ug.user_last_name AS patron_last_name,
+    ug.user_first_name AS patron_first_name,
+    ug.user_middle_name AS patron_middle_name,
+    ug.user_email AS patron_email,
+    lsp.location_name AS location_name,
+    lsp.service_point_discovery_display_name AS service_point_display_name
+FROM
+    public.audit_circulation_logs AS ac
+    LEFT JOIN items_array AS ia ON ac.id = ia.log_id
+    LEFT JOIN folio_reporting.users_groups AS ug ON json_extract_path_text(ac.data, 'linkToIds', 'userId') = ug.user_id
+    LEFT JOIN folio_reporting.locations_service_points AS lsp ON ac.service_point_id = lsp.service_point_id
+WHERE
     ac.date >= (SELECT start_date FROM parameters)
     AND ac.date < (SELECT end_date FROM parameters)
     AND (
@@ -58,15 +56,16 @@ SELECT
         OR '' = (SELECT action_location_filter FROM parameters)
     )
     AND (
-        ac.action IN ((SELECT action_filter1 FROM parameters),
-                      (SELECT action_filter2 FROM parameters),
-                      (SELECT action_filter3 FROM parameters),
+        ac.action IN ((SELECT action_filter1 FROM parameters), 
+                      (SELECT action_filter2 FROM parameters), 
+                      (SELECT action_filter3 FROM parameters), 
                       (SELECT action_filter4 FROM parameters)
-                    )
-        OR ('' = (SELECT action_filter1 FROM parameters) AND
-            '' = (SELECT action_filter2 FROM parameters) AND
-            '' = (SELECT action_filter3 FROM parameters) AND
+                      )
+        OR (
+            '' = (SELECT action_filter1 FROM parameters) AND 
+            '' = (SELECT action_filter2 FROM parameters) AND 
+            '' = (SELECT action_filter3 FROM parameters) AND 
             '' = (SELECT action_filter4 FROM parameters)
-            )
-    )     
-;   
+        )
+    )
+;


### PR DESCRIPTION
relevant data seems to come and go in folio_snapshot. We've had luck with the `folio_snapshot_20210414` database, but other dates might also work.