### PR TITLE
Fix to address the duplication of transaction rows

### DIFF
--- a/sql/derived_tables/finance_transaction_invoices.sql
+++ b/sql/derived_tables/finance_transaction_invoices.sql
@@ -36,7 +36,7 @@ FROM
     LEFT JOIN invoice_invoices AS ii ON json_extract_path_text(ft.data, 'sourceInvoiceId') = ii.id
     LEFT JOIN invoice_lines AS il ON json_extract_path_text(ft.data, 'sourceInvoiceLineId') = il.id
     LEFT JOIN finance_funds AS ff ON ft.from_fund_id = ff.id
-    LEFT JOIN finance_budgets AS fb ON ft.from_fund_id = fb.fund_id
+    LEFT JOIN finance_budgets AS fb ON ft.from_fund_id = fb.fund_id AND ft.fiscal_year_id = fb.fiscal_year_id
     LEFT JOIN organization_organizations AS oo ON json_extract_path_text(ii.data, 'vendorId') = oo.id
 WHERE
     transaction_type = 'Pending payment'

--- a/sql/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql/derived_tables/finance_transaction_purchase_order.sql
@@ -38,7 +38,7 @@ FROM
     LEFT JOIN po_lines AS pol ON json_extract_path_text(ft.data, 'encumbrance', 'sourcePoLineId') = pol.id
     LEFT JOIN po_purchase_orders AS po ON json_extract_path_text(ft.data, 'encumbrance', 'sourcePurchaseOrderId') = po.id
     LEFT JOIN finance_funds AS ff ON ft.from_fund_id = ff.id
-    LEFT JOIN finance_budgets AS fb ON ft.from_fund_id = fb.fund_id
+    LEFT JOIN finance_budgets AS fb ON ft.from_fund_id = fb.fund_id AND ft.fiscal_year_id = fb.fiscal_year_id
     LEFT JOIN organization_organizations AS oo ON po.vendor = oo.id
 WHERE
     ft.transaction_type = 'Encumbrance';

--- a/sql_metadb/derived_tables/finance_transaction_invoices.sql
+++ b/sql_metadb/derived_tables/finance_transaction_invoices.sql
@@ -36,7 +36,7 @@ FROM
     LEFT JOIN folio_invoice.invoices AS ii ON json_extract_path_text(ft.jsonb, 'sourceInvoiceId') = ii.id
     LEFT JOIN folio_invoice.invoice_lines AS il ON json_extract_path_text(ft.jsonb, 'sourceInvoiceLineId') = il.id
     LEFT JOIN folio_finance.fund AS ff ON ft.fromfundid = ff.id
-    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid
+    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid= fb.fiscalyearid
     LEFT JOIN folio_organizations. organizations AS oo ON json_extract_path_text(ii.jsonb, 'vendorId') = oo.id
 WHERE (json_extract_path_text(ft.jsonb, 'transactionType') = 'Pending payment'
     OR json_extract_path_text(ft.jsonb, 'transactionType') = 'Payment');

--- a/sql_metadb/derived_tables/finance_transaction_invoices.sql
+++ b/sql_metadb/derived_tables/finance_transaction_invoices.sql
@@ -36,7 +36,7 @@ FROM
     LEFT JOIN folio_invoice.invoices AS ii ON json_extract_path_text(ft.jsonb, 'sourceInvoiceId') = ii.id
     LEFT JOIN folio_invoice.invoice_lines AS il ON json_extract_path_text(ft.jsonb, 'sourceInvoiceLineId') = il.id
     LEFT JOIN folio_finance.fund AS ff ON ft.fromfundid = ff.id
-    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid= fb.fiscalyearid
+    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid = fb.fiscalyearid
     LEFT JOIN folio_organizations. organizations AS oo ON json_extract_path_text(ii.jsonb, 'vendorId') = oo.id
 WHERE (json_extract_path_text(ft.jsonb, 'transactionType') = 'Pending payment'
     OR json_extract_path_text(ft.jsonb, 'transactionType') = 'Payment');

--- a/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
@@ -38,7 +38,7 @@ FROM
     LEFT JOIN folio_orders.po_line AS pol ON json_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePoLineId') = pol.id
     LEFT JOIN folio_orders.purchase_order AS po ON json_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePurchaseOrderId') = po.id
     LEFT JOIN folio_finance.fund AS ff ON ft.fromfundid = ff.id
-    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid
+    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid= fb.fiscalyearid
     LEFT JOIN folio_organizations. organizations AS oo ON json_extract_path_text(po.jsonb, 'vendor') = oo.id
 WHERE
     json_extract_path_text(ft.jsonb, 'transactionType') = 'Encumbrance';

--- a/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
@@ -38,7 +38,7 @@ FROM
     LEFT JOIN folio_orders.po_line AS pol ON json_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePoLineId') = pol.id
     LEFT JOIN folio_orders.purchase_order AS po ON json_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePurchaseOrderId') = po.id
     LEFT JOIN folio_finance.fund AS ff ON ft.fromfundid = ff.id
-    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid= fb.fiscalyearid
+    LEFT JOIN folio_finance.budget AS fb ON ft.fromfundid = fb.fundid AND ft.fiscalyearid = fb.fiscalyearid
     LEFT JOIN folio_organizations. organizations AS oo ON json_extract_path_text(po.jsonb, 'vendor') = oo.id
 WHERE
     json_extract_path_text(ft.jsonb, 'transactionType') = 'Encumbrance';


### PR DESCRIPTION
Fixed issue that caused transactions to be duplicated because of lacking fiscal_year_id as additional key