### PR TITLE
fixing timestamp conversion in services_usage and loans_items

### DIFF
--- a/sql/derived_tables/loans_items.sql
+++ b/sql/derived_tables/loans_items.sql
@@ -29,7 +29,7 @@ SELECT
     cl.loan_date,
     cl.due_date AS loan_due_date,
     cl.return_date AS loan_return_date,
-    json_extract_path_text(cl.data, 'systemReturnDate') AS system_return_date,
+    json_extract_path_text(cl.data, 'systemReturnDate')::timestamptz at time zone 'UTC' AS system_return_date,
     json_extract_path_text(cl.data, 'checkinServicePointId') AS checkin_service_point_id,
     ispi.discovery_display_name AS checkin_service_point_name,
     json_extract_path_text(cl.data, 'checkoutServicePointId') AS checkout_service_point_id,

--- a/sql/derived_tables/loans_items.sql
+++ b/sql/derived_tables/loans_items.sql
@@ -29,7 +29,7 @@ SELECT
     cl.loan_date,
     cl.due_date AS loan_due_date,
     cl.return_date AS loan_return_date,
-    json_extract_path_text(cl.data, 'systemReturnDate')::timestamptz at time zone 'UTC' AS system_return_date,
+    json_extract_path_text(cl.data, 'systemReturnDate')::timestamptz AS system_return_date,
     json_extract_path_text(cl.data, 'checkinServicePointId') AS checkin_service_point_id,
     ispi.discovery_display_name AS checkin_service_point_name,
     json_extract_path_text(cl.data, 'checkoutServicePointId') AS checkout_service_point_id,

--- a/sql/report_queries/services_usage/services_usage.sql
+++ b/sql/report_queries/services_usage/services_usage.sql
@@ -21,7 +21,7 @@ date filter, then checkout actions that match, then just unions them together
 WITH parameters AS (
     SELECT
         '2000-01-01'::date AS start_date,
-        '2021-01-01'::date AS end_date
+        '2022-01-01'::date AS end_date
 ),
 checkout_actions AS (
     SELECT
@@ -37,29 +37,22 @@ checkout_actions AS (
 FROM
     folio_reporting.loans_items
     WHERE
-        loan_date >= (
-            SELECT
-                start_date
-            FROM
-                parameters)
-            AND loan_date < (
-                SELECT
-                    end_date
-                FROM
-                    parameters)
-            GROUP BY
-                service_point_name,
-                action_date,
-                day_of_week,
-                hour_of_day,
-                material_type_name,
-                item_effective_location_name_at_check_out,
-                item_status
+        loan_date >= (SELECT start_date FROM parameters)
+        AND loan_date < (SELECT end_date FROM parameters)
+    GROUP BY
+        service_point_name,
+        action_date,
+        day_of_week,
+        hour_of_day,
+        material_type_name,
+        item_effective_location_name_at_check_out,
+        item_status
 ),
 simple_return_dates AS (
     SELECT
         checkin_service_point_name AS service_point_name,
-        coalesce(system_return_date, loan_return_date::timestamptz at time zone 'UTC') AS action_date,
+        coalesce(system_return_date::timestamptz at time zone 'UTC', 
+            loan_return_date::timestamptz at time zone 'UTC') AS action_date,
         material_type_name,
         'Checkin'::varchar AS action_type,
         item_effective_location_name_at_check_out,
@@ -74,66 +67,58 @@ checkin_actions AS (
         action_date::date AS action_date,
         to_char(action_date, 'Day') AS day_of_week,
         extract(hours FROM action_date) AS hour_of_day,
+        material_type_name,
+        action_type,
+        item_effective_location_name_at_check_out,
+        item_status,
+        count(loan_id) AS ct
+    FROM
+        simple_return_dates
+    WHERE
+        action_date >= (SELECT start_date FROM parameters)
+        AND action_date < (SELECT end_date FROM parameters)
+    GROUP BY
+        service_point_name,
+        action_date,
+        day_of_week,
+        hour_of_day,
+        material_type_name,
+        action_type,
+        item_effective_location_name_at_check_out,
+        item_status
+)
+SELECT
+    service_point_name,
+    action_date,
+    day_of_week,
+    hour_of_day,
     material_type_name,
     action_type,
     item_effective_location_name_at_check_out,
     item_status,
-    count(loan_id) AS ct
+    ct
 FROM
-    simple_return_dates
-    WHERE
-        action_date >= (
-            SELECT
-                start_date
-            FROM
-                parameters)
-            AND action_date < (
-                SELECT
-                    end_date
-                FROM
-                    parameters)
-            GROUP BY
-                service_point_name,
-                action_date,
-                day_of_week,
-                hour_of_day,
-                material_type_name,
-                action_type,
-                item_effective_location_name_at_check_out,
-                item_status
-)
-    SELECT
-        service_point_name,
-        action_date,
-        day_of_week,
-        hour_of_day,
-        material_type_name,
-        action_type,
-        item_effective_location_name_at_check_out,
-        item_status,
-        ct
-    FROM
-        checkout_actions
-    UNION ALL
-    SELECT
-        service_point_name,
-        action_date,
-        day_of_week,
-        hour_of_day,
-        material_type_name,
-        action_type,
-        item_effective_location_name_at_check_out,
-        item_status,
-        ct
-    FROM
-        checkin_actions
-    ORDER BY
-        service_point_name,
-        action_date,
-        day_of_week,
-        hour_of_day,
-        material_type_name,
-        action_type,
-        item_effective_location_name_at_check_out,
-        item_status;
+    checkout_actions
+UNION ALL
+SELECT
+    service_point_name,
+    action_date,
+    day_of_week,
+    hour_of_day,
+    material_type_name,
+    action_type,
+    item_effective_location_name_at_check_out,
+    item_status,
+    ct
+FROM
+    checkin_actions
+ORDER BY
+    service_point_name,
+    action_date,
+    day_of_week,
+    hour_of_day,
+    material_type_name,
+    action_type,
+    item_effective_location_name_at_check_out,
+    item_status;
 

--- a/sql/report_queries/services_usage/services_usage.sql
+++ b/sql/report_queries/services_usage/services_usage.sql
@@ -51,8 +51,8 @@ FROM
 simple_return_dates AS (
     SELECT
         checkin_service_point_name AS service_point_name,
-        coalesce(system_return_date::timestamptz at time zone 'UTC', 
-            loan_return_date::timestamptz at time zone 'UTC') AS action_date,
+        coalesce(system_return_date::timestamptz, 
+            loan_return_date::timestamptz) AS action_date,
         material_type_name,
         'Checkin'::varchar AS action_type,
         item_effective_location_name_at_check_out,


### PR DESCRIPTION
JSON extract results in a string field in the derived table, so query was failing. fixing both the derived table and the report query, for good measure. Additional slight formatting changes for readability and consistency.