### PR TITLE
Corrected data type and column names

### DIFF
--- a/sql_metadb/derived_tables/agreements_subscription_agreement_org_ext.sql
+++ b/sql_metadb/derived_tables/agreements_subscription_agreement_org_ext.sql
@@ -4,15 +4,15 @@ DROP TABLE IF EXISTS agreements_subscription_agreement_org_ext;
 -- resolves values and labels from erm_agreements_refdata_value for sao_role
 CREATE TABLE agreements_subscription_agreement_org_ext AS
 SELECT
-    sao_id,
-    sao_owner_fk AS subscription_agreement_id,
-    sao_org_fk AS sao_org_id,
+    sao.sao_id,
+    sao.sao_owner_fk AS subscription_agreement_id,
+    sao.sao_org_fk AS sao_org_id,
     org.org_name AS sao_org_name,
-    sao_role AS sao_role_id,
+    sao.sao_role AS sao_role_id,
     saor.rdv_value AS sao_role_value,
     saor.rdv_label AS sao_role_label,
-    sao_note,
-    org_orgs_uuid
+    sao.sao_note,
+    org.org_orgs_uuid::uuid
 FROM
     folio_agreements.subscription_agreement_org AS sao
     LEFT JOIN folio_agreements.refdata_value AS saor ON sao.sao_role = saor.rdv_id

--- a/sql_metadb/derived_tables/licenses_license_ext.sql
+++ b/sql_metadb/derived_tables/licenses_license_ext.sql
@@ -9,20 +9,21 @@ DROP TABLE IF EXISTS licenses_license_ext;
 --   folio_licenses.refdata_value
 CREATE TABLE licenses_license_ext AS
 SELECT
-    licenses_license.lic_id AS "license_id",
-    licenses_license.lic_name AS "license_name",
-    licenses_license.lic_description AS "license_description",
-    licenses_license.lic_start_date AS "license_start",
-    licenses_license.lic_end_date AS "license_end",
-    licenses_refdata_value2.rdv_value AS "license_type",
-    licenses_refdata_value3.rdv_value AS "license_status",
-    licenses_license_org2.org_name AS "license_org",
-    licenses_refdata_value.rdv_label AS "license_org_role",
-    licenses_license_org2.org_orgs_uuid AS "license_org_uuid"
-FROM (folio_licenses.license AS licenses_license
+    licenses_license.lic_id AS license_id,
+    licenses_license.lic_name AS license_name,
+    licenses_license.lic_description AS license_description,
+    licenses_license.lic_start_date AS license_start,
+    licenses_license.lic_end_date AS license_end,
+    licenses_refdata_value2.rdv_value AS license_type,
+    licenses_refdata_value3.rdv_value AS license_status,
+    licenses_license_org2.org_name AS license_org,
+    licenses_refdata_value.rdv_label AS license_org_role,
+    licenses_license_org2.org_orgs_uuid::uuid AS license_org_uuid
+FROM 
+	folio_licenses.license AS licenses_license
     LEFT JOIN folio_licenses.license_org AS licenses_license_org ON licenses_license.lic_id = licenses_license_org.sao_owner_fk
     LEFT JOIN folio_licenses.org AS licenses_license_org2 ON licenses_license_org.sao_org_fk = licenses_license_org2.org_id
-    LEFT JOIN folio_licenses.refdata_value AS licenses_refdata_value ON licenses_refdata_value.rdv_id = licenses_license_org.sao_role)
+    LEFT JOIN folio_licenses.refdata_value AS licenses_refdata_value ON licenses_refdata_value.rdv_id = licenses_license_org.sao_role
     LEFT JOIN folio_licenses.refdata_value AS licenses_refdata_value2 ON licenses_refdata_value2.rdv_id = licenses_license.lic_type_rdv_fk
     LEFT JOIN folio_licenses.refdata_value AS licenses_refdata_value3 ON licenses_refdata_value3.rdv_id = licenses_license.lic_status_rdv_fk;
 


### PR DESCRIPTION
Column names now without quotes and data type for column "license_org_uuid" changed to UUID. The UUID for "license_id" must still be of the data type varchar (app-internal specification). "license_start" and "license_end" remain integer and must later be set to data type timestamptz. This is currently not possible. 
#551 