### PR TITLE
MM - Port Over Derived Table Instance format ids for Metadb

### DIFF
--- a/sql_metadb/derived_tables/instance_formats.sql
+++ b/sql_metadb/derived_tables/instance_formats.sql
@@ -1,0 +1,42 @@
+-- Create derived table for instance formats bringing together the identifier and name 
+-- Note: Because of inaccurate data in FOLIO, instance_format_id is a varchar and the ift.id has to be cast as a varchar.
+DROP TABLE IF EXISTS instance_formats;
+
+CREATE TABLE instance_formats AS
+WITH instances AS (
+    SELECT
+        i.id AS instance_id,
+        jsonb_extract_path_text(i.jsonb, 'hrid') AS instance_hrid,
+        instance_format_ids.jsonb #>> '{}' AS instance_format_id,
+        instance_format_ids.ordinality AS instance_format_ordinality
+    FROM
+        folio_inventory.instance i
+        CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(i.jsonb, 'instanceFormatIds')) WITH ORDINALITY AS instance_format_ids (jsonb)
+)
+SELECT
+    it.instance_id,
+    it.instance_hrid,
+    it.instance_format_id,
+    it.instance_format_ordinality,
+    ift.code AS instance_format_code,
+    ift.name AS instance_format_name,
+    ift.source AS instance_format_source
+FROM
+    instances AS it  
+    LEFT JOIN folio_inventory.instance_format__t AS ift ON it.instance_format_id = ift.id::varchar ;
+
+CREATE INDEX ON instance_formats (instance_id);
+
+CREATE INDEX ON instance_formats (instance_hrid);
+
+CREATE INDEX ON instance_formats (instance_format_id);
+
+CREATE INDEX ON instance_formats (instance_format_ordinality);
+
+CREATE INDEX ON instance_formats (instance_format_code);
+
+CREATE INDEX ON instance_formats (instance_format_name);
+
+CREATE INDEX ON instance_formats (instance_format_source);
+
+VACUUM ANALYZE instance_formats;

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -13,6 +13,7 @@ instance_contributors.sql
 instance_alternative_titles.sql
 instance_electronic_access.sql
 instance_statistical_codes.sql
+instance_formats.sql
 invoice_adjustments_in_addition_to.sql
 invoice_adjustments_ext.sql
 licenses_license_ext.sql


### PR DESCRIPTION
New ported over instance formats derived table for Metadb.

**NOTE**: There is a problem with some of the FOLIO data for format ids. Instead of a uuid, there is text information. I had to treat the uuids here as varchar because of that.