### PR TITLE
Create metadb derived table item_notes

### DIFF
--- a/sql_metadb/derived_tables/item_notes.sql
+++ b/sql_metadb/derived_tables/item_notes.sql
@@ -1,4 +1,5 @@
 -- MetaDB version of item_notes
+-- This derived table extracts the nested array item notes
 DROP TABLE IF EXISTS item_notes;
 
 CREATE TABLE item_notes AS

--- a/sql_metadb/derived_tables/item_notes.sql
+++ b/sql_metadb/derived_tables/item_notes.sql
@@ -7,7 +7,7 @@ SELECT
     i__t.id AS item_id,
     i__t.hrid AS item_hrid,
     i__t.holdings_record_id AS holdings_record_id,
-    jsonb_extract_path_text(notes.data, 'itemNoteTypeId') AS note_type_id,
+    jsonb_extract_path_text(notes.data, 'itemNoteTypeId')::uuid AS note_type_id,
     int__t.name AS note_type_name,
     jsonb_extract_path_text(notes.data, 'note') AS note,
     jsonb_extract_path_text(notes.data, 'staffOnly')::boolean AS staff_only,

--- a/sql_metadb/derived_tables/item_notes.sql
+++ b/sql_metadb/derived_tables/item_notes.sql
@@ -1,0 +1,37 @@
+-- MetaDB version of item_notes
+DROP TABLE IF EXISTS item_notes;
+
+CREATE TABLE item_notes AS
+SELECT
+    i__t.id AS item_id,
+    i__t.hrid AS item_hrid,
+    i__t.holdings_record_id AS holdings_record_id,
+    jsonb_extract_path_text(notes.data, 'itemNoteTypeId') AS note_type_id,
+    int__t.name AS note_type_name,
+    jsonb_extract_path_text(notes.data, 'note') AS note,
+    jsonb_extract_path_text(notes.data, 'staffOnly')::boolean AS staff_only,
+    notes.ordinality AS note_ordinality
+FROM
+    folio_inventory.item AS i
+    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'notes')) WITH ORDINALITY AS notes (data)
+    LEFT JOIN folio_inventory.item__t AS i__t ON i.id = i__t.id
+    LEFT JOIN folio_inventory.item_note_type__t AS int__t ON jsonb_extract_path_text(notes.data, 'itemNoteTypeId')::uuid = int__t.id    
+;
+
+CREATE INDEX ON item_notes (item_id);
+
+CREATE INDEX ON item_notes (item_hrid);
+
+CREATE INDEX ON item_notes (holdings_record_id);
+
+CREATE INDEX ON item_notes (note_type_id);
+
+CREATE INDEX ON item_notes (note_type_name);
+
+CREATE INDEX ON item_notes (note);
+
+CREATE INDEX ON item_notes (staff_only);
+
+CREATE INDEX ON item_notes (note_ordinality);
+
+VACUUM ANALYZE item_notes;

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -26,5 +26,6 @@ po_lines_er_mat_type.sql
 po_lines_eresource.sql
 po_lines_phys_mat_type.sql
 item_ext.sql
+item_notes.sql
 loans_items.sql
 loans_renewal_count.sql


### PR DESCRIPTION
Create a metadb derived table for notes on items. Table creates a new entry for every note and detailing type of note, note content, visibility of staff only or not, and the ordinality of the note appear in the item record.