### PR TITLE
Create metadb derived table items_holdings_instances

### DIFF
--- a/sql_metadb/derived_tables/items_holdings_instances.sql
+++ b/sql_metadb/derived_tables/items_holdings_instances.sql
@@ -11,7 +11,6 @@ SELECT
     ii.chronology,
     ii.enumeration,
     ii.volume,
-    ii.holdings_record_id,
     ii.hrid AS item_hrid,
     ii.item_identifier,
     ii.item_level_call_number,
@@ -53,8 +52,6 @@ CREATE INDEX ON items_holdings_instances (chronology);
 CREATE INDEX ON items_holdings_instances (volume);
 
 CREATE INDEX ON items_holdings_instances (enumeration);
-
-CREATE INDEX ON items_holdings_instances (holdings_record_id);
 
 CREATE INDEX ON items_holdings_instances (item_hrid);
 

--- a/sql_metadb/derived_tables/items_holdings_instances.sql
+++ b/sql_metadb/derived_tables/items_holdings_instances.sql
@@ -1,0 +1,101 @@
+DROP TABLE IF EXISTS items_holdings_instances;
+
+-- Create an extended items table that includes holdings and instances
+-- information such as call number, material type, title, etc.
+
+CREATE TABLE items_holdings_instances AS
+SELECT
+    ii.id AS item_id,
+    ii.barcode,
+    ii.copy_number AS item_copy_number,
+    ii.chronology,
+    ii.enumeration,
+    ii.volume,
+    ii.holdings_record_id,
+    ii.hrid AS item_hrid,
+    ii.item_identifier,
+    ii.item_level_call_number,
+    ih.call_number_type_id,
+    icnt.name AS call_number_type_name,
+    ii.material_type_id,
+    imt.name AS material_type_name,
+    ii.number_of_pieces,
+    ih.id AS holdings_id,
+    ih.call_number,
+    ih.acquisition_method,
+    ih.copy_number AS holdings_copy_number,
+    ih.holdings_type_id,
+    iht.name AS holdings_type_name,
+    ih.instance_id,
+    ih.shelving_title,
+    ii2.cataloged_date,
+    ii2.index_title,
+    ii2.title,
+    ilt.id AS loan_type_id,
+    ilt.name AS loan_type_name
+FROM
+    folio_inventory.item__t AS ii
+    LEFT JOIN folio_inventory.holdings_record__t AS ih ON ii.holdings_record_id = ih.id
+    LEFT JOIN folio_inventory.instance__t AS ii2 ON ih.instance_id = ii2.id
+    LEFT JOIN folio_inventory.loan_type__t AS ilt ON ii.permanent_loan_type_id = ilt.id
+    LEFT JOIN folio_inventory.material_type__t AS imt ON ii.material_type_id = imt.id
+    LEFT JOIN folio_inventory.holdings_type__t AS iht ON ih.holdings_type_id = iht.id
+    LEFT JOIN folio_inventory.call_number_type__t AS icnt ON ih.call_number_type_id = icnt.id;
+
+CREATE INDEX ON items_holdings_instances (item_id);
+
+CREATE INDEX ON items_holdings_instances (barcode);
+
+CREATE INDEX ON items_holdings_instances (item_copy_number);
+
+CREATE INDEX ON items_holdings_instances (chronology);
+
+CREATE INDEX ON items_holdings_instances (volume);
+
+CREATE INDEX ON items_holdings_instances (enumeration);
+
+CREATE INDEX ON items_holdings_instances (holdings_record_id);
+
+CREATE INDEX ON items_holdings_instances (item_hrid);
+
+CREATE INDEX ON items_holdings_instances (item_identifier);
+
+CREATE INDEX ON items_holdings_instances (item_level_call_number);
+
+CREATE INDEX ON items_holdings_instances (call_number_type_id);
+
+CREATE INDEX ON items_holdings_instances (call_number_type_name);
+
+CREATE INDEX ON items_holdings_instances (material_type_id);
+
+CREATE INDEX ON items_holdings_instances (material_type_name);
+
+CREATE INDEX ON items_holdings_instances (number_of_pieces);
+
+CREATE INDEX ON items_holdings_instances (holdings_id);
+
+CREATE INDEX ON items_holdings_instances (call_number);
+
+CREATE INDEX ON items_holdings_instances (acquisition_method);
+
+CREATE INDEX ON items_holdings_instances (holdings_copy_number);
+
+CREATE INDEX ON items_holdings_instances (holdings_type_id);
+
+CREATE INDEX ON items_holdings_instances (holdings_type_name);
+
+CREATE INDEX ON items_holdings_instances (instance_id);
+
+CREATE INDEX ON items_holdings_instances (shelving_title);
+
+CREATE INDEX ON items_holdings_instances (cataloged_date);
+
+CREATE INDEX ON items_holdings_instances (index_title);
+
+CREATE INDEX ON items_holdings_instances (title);
+
+CREATE INDEX ON items_holdings_instances (loan_type_id);
+
+CREATE INDEX ON items_holdings_instances (loan_type_name);
+
+VACUUM ANALYZE items_holdings_instances;

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -36,6 +36,7 @@ po_lines_phys_mat_type.sql
 po_lines_physical.sql
 po_ongoing.sql
 item_ext.sql
+items_holdings_instances.sql
 loans_items.sql
 loans_renewal_count.sql
 po_lines_tags.sql


### PR DESCRIPTION
Create a metadb derived table for linking items to holdings to instance. Table is primarily item level with piece information such as volume and material type, but also has holding level details like call number fields, and at the instance level with title and cataloged date.