### PR TITLE
Create metadb derived table item_tags

### DIFF
--- a/sql_metadb/derived_tables/item_tags.sql
+++ b/sql_metadb/derived_tables/item_tags.sql
@@ -1,0 +1,21 @@
+-- metadb -- item_tags
+-- This table creates a listing of items and their tag(s).
+
+DROP TABLE IF EXISTS item_tags;
+
+CREATE TABLE item_tags AS
+SELECT
+    i.id AS item_id,
+    tags.data #>> '{}' AS item_tag,
+    tags.ordinality AS item_tag_ordinality
+FROM
+    folio_inventory.item AS i
+    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'tags', 'tagList')) WITH ORDINALITY AS tags(data);
+
+CREATE INDEX ON item_tags (item_id);
+
+CREATE INDEX ON item_tags (item_tag);
+
+CREATE INDEX ON item_tags (item_tag_ordinality);
+
+VACUUM ANALYZE item_tags;

--- a/sql_metadb/derived_tables/item_tags.sql
+++ b/sql_metadb/derived_tables/item_tags.sql
@@ -6,13 +6,17 @@ DROP TABLE IF EXISTS item_tags;
 CREATE TABLE item_tags AS
 SELECT
     i.id AS item_id,
+    it.hrid AS item_hrid,
     tags.data #>> '{}' AS item_tag,
     tags.ordinality AS item_tag_ordinality
 FROM
     folio_inventory.item AS i
-    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'tags', 'tagList')) WITH ORDINALITY AS tags(data);
+    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'tags', 'tagList')) WITH ORDINALITY AS tags(data)
+    LEFT JOIN folio_inventory.item__t AS it ON i.id = it.id;
 
 CREATE INDEX ON item_tags (item_id);
+
+CREATE INDEX ON item_tags (item_hrid);
 
 CREATE INDEX ON item_tags (item_tag);
 

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -36,6 +36,7 @@ po_lines_phys_mat_type.sql
 po_lines_physical.sql
 po_ongoing.sql
 item_ext.sql
+item_tags.sql
 loans_items.sql
 loans_renewal_count.sql
 po_lines_tags.sql


### PR DESCRIPTION
Create a metadb derived table for items with tags. Table contains a new row for every tag associated with an item record and contains the name of the tag and ordinality the tag appears in.