### PR TITLE
MM new metadb derived table item_administrative_notes

### DIFF
--- a/sql_metadb/derived_tables/item_administrative_notes.sql
+++ b/sql_metadb/derived_tables/item_administrative_notes.sql
@@ -1,0 +1,26 @@
+-- This derived table extracts administrative notes from the item record.
+DROP TABLE IF EXISTS item_administrative_notes;
+
+CREATE TABLE item_administrative_notes AS
+SELECT
+    it.id AS item_id,
+    it.hrid AS item_hrid,
+    it.holdings_record_id AS holdings_record_id,
+    adminNotes.jsonb #>> '{}' AS administrative_note,
+    adminNotes.ordinality AS administrative_note_ordinality
+FROM
+    folio_inventory.item AS i
+    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'administrativeNotes')) WITH ORDINALITY AS adminNotes (jsonb)
+    LEFT JOIN folio_inventory.item__t AS it ON i.id = it.id;
+
+CREATE INDEX ON item_administrative_notes (item_id);
+
+CREATE INDEX ON item_administrative_notes (item_hrid);
+
+CREATE INDEX ON item_administrative_notes (holdings_record_id);
+
+CREATE INDEX ON item_administrative_notes (administrative_note);
+
+CREATE INDEX ON item_administrative_notes (administrative_note_ordinality);
+
+VACUUM ANALYZE item_administrative_notes;

--- a/sql_metadb/derived_tables/item_administrative_notes.sql
+++ b/sql_metadb/derived_tables/item_administrative_notes.sql
@@ -6,11 +6,11 @@ SELECT
     it.id AS item_id,
     it.hrid AS item_hrid,
     it.holdings_record_id AS holdings_record_id,
-    adminNotes.jsonb #>> '{}' AS administrative_note,
-    adminNotes.ordinality AS administrative_note_ordinality
+    admin_notes.jsonb #>> '{}' AS administrative_note,
+    admin_notes.ordinality AS administrative_note_ordinality
 FROM
     folio_inventory.item AS i
-    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'administrativeNotes')) WITH ORDINALITY AS adminNotes (jsonb)
+    CROSS JOIN LATERAL jsonb_array_elements(jsonb_extract_path(jsonb, 'administrativeNotes')) WITH ORDINALITY AS admin_notes (jsonb)
     LEFT JOIN folio_inventory.item__t AS it ON i.id = it.id;
 
 CREATE INDEX ON item_administrative_notes (item_id);

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -42,6 +42,7 @@ po_lines_eresource.sql
 po_lines_phys_mat_type.sql
 po_lines_physical.sql
 po_ongoing.sql
+item_administrative_notes.sql
 item_ext.sql
 item_electronic_access.sql
 item_notes.sql


### PR DESCRIPTION
This table extracts administrative notes from item records. Must use Lotus for fields to be present.