### PR TITLE
ERM - Bugfix erm_agreement_package_content_item_list.sql

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,4 @@
 * A new derived table for LDP 1.x, `instance_administrative_notes`,
   extracts administrative notes from instance records.
 
+* Fixed error in erm_agreement_package_content_item_list.sql

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,4 +3,4 @@
 * A new derived table for LDP 1.x, `instance_administrative_notes`,
   extracts administrative notes from instance records.
 
-* Fixed error in erm_agreement_package_content_item_list.sql
+* Fixed error in Rpt erm_agreement_package_content_item_list.sql

--- a/sql_metadb/report_queries/erm/agreement_package_content_item_list/erm_agreement_package_content_item_list.sql
+++ b/sql_metadb/report_queries/erm/agreement_package_content_item_list/erm_agreement_package_content_item_list.sql
@@ -1,16 +1,4 @@
-/*
- * description:
- * -------------
- * The report shows e-resources that are covered by an agreement.
- * All identifiers for a title are aggregated and output in the identifier attribute.
- * 
- * tables: 
- * -------------
- * folio_derived.agreements_package_content_item
- * folio_derived.agreements_subscription_agreement_entitlement
- * folio_agreements.work
- * folio_agreements.erm_resource
- */
+-- The report shows e-resource titles that are covered by an agreement.
 SELECT
     erm_pci_titles.w_title AS title,
     erm_agreements.subscription_agreement_name AS agreement,
@@ -25,7 +13,18 @@ SELECT
     erm_pci_list.ti_monograph_edition,
     erm_pci_list.ti_monograph_volume,
     erm_pci_list.ti_first_editor,
-    string_agg(erm_pci_list.identifiernamespace_name || ': ' || erm_pci_list.identifier_value, ', ' ORDER BY erm_pci_list.identifiernamespace_name, erm_pci_list.identifier_value) AS identifier
+    string_agg(
+        -- expression
+        erm_pci_list.identifiernamespace_name || 
+        ': ' || 
+        erm_pci_list.identifier_value,
+        -- separator
+        ', '
+        -- order_by_clause
+        ORDER BY 
+            erm_pci_list.identifiernamespace_name, 
+            erm_pci_list.identifier_value
+    ) AS identifier
 FROM
     folio_derived.agreements_package_content_item AS erm_pci_list
     JOIN folio_agreements.work AS erm_pci_titles ON erm_pci_titles.w_id = erm_pci_list.ti_work_id
@@ -35,9 +34,9 @@ WHERE
     -- Don't use removed titles from packages
     erm_pci_list.pci_removed_ts IS NULL 
 GROUP BY
-    title,
-    agreement,
-    res_name,
+    erm_pci_titles.w_title,
+    erm_agreements.subscription_agreement_name,
+    erm_erm_resource.res_name,
     erm_pci_list.package_source,
     erm_pci_list.org_vendor_name,
     erm_pci_list.remotekb_remote_kb_name,
@@ -49,6 +48,6 @@ GROUP BY
     erm_pci_list.ti_monograph_volume,
     erm_pci_list.ti_first_editor
 ORDER BY
-    title,
-    agreement,
-    res_name;
+    erm_pci_titles.w_title,
+    erm_agreements.subscription_agreement_name,
+    erm_erm_resource.res_name;


### PR DESCRIPTION
Closes #618 

Query ended with error: "Column reference 'res_name' is ambiguous". This error has been corrected.

```
All queries:
- [ ] Release notes added or updated in CHANGES.md
- [ ] Query runs without errors
- [ ] Query output is correct
- [ ] Query logic is clear and well documented
- [ ] Query is readable and properly indented with spaces (not tabs)
- [ ] Table and column names are in all-lowercase
- [ ] Quotation marks are used only where necessary

Report queries:
- [ ] Query has complete user documentation
    - [ ] Purpose of report
    - [ ] Sample output
    - [ ] Query instructions

Derived tables:
- [ ] Query begins with user documentation in comment lines
- [ ] File name is listed in `runlist.txt` after dependencies
- [ ] All columns have indexes
- [ ] Table is vacuumed and analyzed
```
