### PR TITLE
Add columns to ldp_add_columns.conf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,4 +2,5 @@
 
 * A new derived table for LDP 1.x, `instance_administrative_notes`,
   extracts administrative notes from instance records.
-
+* Additional columns added to `ldp_add_columns.conf`:
+  `finance_funds.fund_type_id` and `finance_transactions.description`.

--- a/sql/require_columns/ldp_add_column.conf
+++ b/sql/require_columns/ldp_add_column.conf
@@ -2,6 +2,8 @@ circulation_loans.checkin_service_point_id varchar
 circulation_loans.claimed_returned_date timestamptz
 circulation_loans.return_date timestamptz
 circulation_loans.system_return_date timestamptz
+finance_funds.fund_type_id varchar
+finance_transactions.description varchar
 inventory_holdings.acquisition_method varchar
 inventory_holdings.call_number_prefix varchar
 inventory_holdings.call_number_suffix varchar
@@ -59,4 +61,3 @@ invoice_vouchers.voucher_date timestamptz
 invoice_vouchers.voucher_number varchar
 po_purchase_orders.po_number varchar
 po_purchase_orders.vendor varchar
-


### PR DESCRIPTION
Add columns `finance_funds.fund_type_id` and `finance_transactions.description`. Allows the building of some finance tables when data is lacking.

Update has been tested against LDP 1.x datasets.