### PR TITLE
Remove duplicate field from items_holdings_instances (bugfix for 1.5.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
 
 * Fixed error "Column reference `res_name` is ambiguous" in report
   `erm_agreement_package_content_item_list`.
-  
+
 * Ported derived table `invoice_lines_adjustments` from LDP1.
 
 * Updated report query `erm_agreement_cancellation_dates` with
@@ -47,3 +47,4 @@
 
 * Fixed timestamp data types in derived table `item_ext`.
 
+* Fixed error "Duplicate column in `items_holdings_instances` derived table"

--- a/sql/derived_tables/items_holdings_instances.sql
+++ b/sql/derived_tables/items_holdings_instances.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS items_holdings_instances;
-
 -- Create an extended items table that includes holdings and instances
 -- information such as call number, material type, title, etc.
 --
@@ -12,6 +10,8 @@ DROP TABLE IF EXISTS items_holdings_instances;
 --     inventory_holdings_types
 --     inventory_call_number_types
 --
+DROP TABLE IF EXISTS items_holdings_instances;
+
 CREATE TABLE items_holdings_instances AS
 SELECT
     ii.id AS item_id,
@@ -19,7 +19,6 @@ SELECT
     ii.chronology,
     ii.copy_number AS item_copy_number,
     ii.enumeration,
-    ii.holdings_record_id,
     ii.hrid,
     ii.item_identifier,
     ii.item_level_call_number,
@@ -59,8 +58,6 @@ CREATE INDEX ON items_holdings_instances (chronology);
 CREATE INDEX ON items_holdings_instances (item_copy_number);
 
 CREATE INDEX ON items_holdings_instances (enumeration);
-
-CREATE INDEX ON items_holdings_instances (holdings_record_id);
 
 CREATE INDEX ON items_holdings_instances (hrid);
 


### PR DESCRIPTION
Fixes #693

Looked to the metadb version to decide which field to remove. Also noticed documentation was not at top of query, so moved that as well.

```
All queries:
- [x] Release notes added or updated in CHANGES.md
- [x] Query runs without errors
- [x] Query output is correct
- [x] Query logic is clear and well documented
- [x] Query is readable and properly indented with spaces (not tabs)
- [x] Table and column names are in all-lowercase
- [x] Quotation marks are used only where necessary

Derived tables:
- [x] Query begins with user documentation in comment lines
- [x] File name is listed in `runlist.txt` after dependencies
- [x] All columns have indexes
- [x] Table is vacuumed and analyzed
```
