### PR TITLE
Add missing descriptive comment in derived tables (bugfix for 1.5.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
 
 * Fixed error "Column reference `res_name` is ambiguous" in report
   `erm_agreement_package_content_item_list`.
-  
+
 * Ported derived table `invoice_lines_adjustments` from LDP1.
 
 * Updated report query `erm_agreement_cancellation_dates` with
@@ -47,3 +47,5 @@
 
 * Fixed timestamp data types in derived table `item_ext`.
 
+* Fixed missing descriptive comments in Metadb derived tables `po_lines_tags` and
+  `invoice_lines_fund_distributions`

--- a/sql_metadb/derived_tables/invoice_lines_fund_distributions.sql
+++ b/sql_metadb/derived_tables/invoice_lines_fund_distributions.sql
@@ -1,3 +1,6 @@
+-- Create a derived table to extract fund_distributions from invoice_lines 
+-- and joining funds related tables.
+
 DROP TABLE IF EXISTS invoice_lines_fund_distributions;
 
 CREATE TABLE invoice_lines_fund_distributions AS

--- a/sql_metadb/derived_tables/po_lines_tags.sql
+++ b/sql_metadb/derived_tables/po_lines_tags.sql
@@ -1,4 +1,4 @@
---po_lines_tags
+-- Creates a derived table for tags in purchase order lines.
 
 DROP TABLE IF EXISTS po_lines_tags;
 


### PR DESCRIPTION
Fixes #596 

Add missing description comment to invoice_lines_fund_distributions and po_lines_tags derived tables for Metadb.

```
All queries:
- [x] Release notes added or updated in CHANGES.md
- [x] Query runs without errors
- [x] Query output is correct
- [x] Query logic is clear and well documented
- [x] Query is readable and properly indented with spaces (not tabs)
- [x] Table and column names are in all-lowercase
- [x] Quotation marks are used only where necessary

Derived tables:
- [x] Query begins with user documentation in comment lines
- [x] File name is listed in `runlist.txt` after dependencies
- [x] All columns have indexes
- [x] Table is vacuumed and analyzed
```
