### PR TITLE
Add missing encumbrance status to derived table `finance_trancaction_purchase_order`  (bugfix for 1.5.0) 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 * Use `timestamptz` columns for data extracted from metadata
   `createdDate` fields.
 
+## 1.5.1
+
+* Add missing encumbrance status to derived table `finance_transaction_purchase_order` for LDP1 and Metadb
 
 ## 1.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 ## 1.5.1
 
 * Add missing encumbrance status to derived table `finance_transaction_purchase_order` for LDP1 and Metadb
+* Added /updated comments to derived tables: `finance_transaction_purchase_order`
 
 ## 1.5.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@
 
 ## 1.5.1
 
-* Add missing encumbrance status to derived table `finance_transaction_purchase_order` for LDP1 and Metadb
+* Add missing encumbrance status and removed not required documentation 
+  in query to derived table `finance_transaction_purchase_order` for LDP1 
+  and Metadb
 * Added /updated comments to derived tables: `finance_transaction_purchase_order`
 
 ## 1.5.0

--- a/sql/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql/derived_tables/finance_transaction_purchase_order.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS finance_transaction_purchase_order;
-
 -- Create a derived table that joins purchase orders and po_lines fields to transactions for encumbranced cost reports in system currency
 --
 -- Tables included:
@@ -8,6 +6,9 @@ DROP TABLE IF EXISTS finance_transaction_purchase_order;
 --    finance_budget
 --    po_lines
 --    po_purchase_orders
+
+DROP TABLE IF EXISTS finance_transaction_purchase_order;
+
 CREATE TABLE finance_transaction_purchase_order AS
 SELECT
     ft.id AS transaction_id,
@@ -25,6 +26,7 @@ SELECT
     json_extract_path_text(ft.data, 'encumbrance', 'initialAmountEncumbered') AS transaction_encumbrance_initial_amount,
     json_extract_path_text(ft.data, 'encumbrance', 'orderType') AS transaction_encumbrance_order_type,
     json_extract_path_text(ft.data, 'encumbrance', 'subscription') AS transaction_encumbrance_subscription,
+    json_extract_path_text(ft.data, 'encumbrance', 'status') AS transaction_encumbrance_status,
     json_extract_path_text(ft.data, 'encumbrance', 'sourcePoLineId') AS po_line_id,
     json_extract_path_text(ft.data, 'encumbrance', 'sourcePurchaseOrderId') AS po_id,
     pol.po_line_number AS pol_number,
@@ -73,6 +75,8 @@ CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_orde
 
 CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_subscription);
 
+CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_status);
+
 CREATE INDEX ON finance_transaction_purchase_order (po_line_id);
 
 CREATE INDEX ON finance_transaction_purchase_order (po_id);
@@ -88,6 +92,54 @@ CREATE INDEX ON finance_transaction_purchase_order (po_order_type);
 CREATE INDEX ON finance_transaction_purchase_order (po_vendor_id);
 
 CREATE INDEX ON finance_transaction_purchase_order (po_vendor_name);
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_id IS 'UUID of this transaction';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_amount IS 'The amount of this transaction. For encumbrances: This is initialAmountEncumbered - (amountAwaitingPayment + amountExpended)';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_currency IS 'Currency code for this transaction - from the system currency';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_expense_class_id IS 'UUID of the associated expense class';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_fiscal_year_id IS 'UUID of the fiscal year that the transaction is taking place in';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_from_fund_id IS 'UUID of the fund money is moving from';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_from_fund_name IS 'The name of this fund';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_from_fund_code IS 'A unique code associated with the fund';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_from_budget_id IS 'UUID of this budget';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_from_budget_name IS 'The name of the budget';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_amount_awaiting_payment IS 'Deprecated! Going to be removed in next release. The amount of awaiting for payment';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_amount_expended IS 'The amount currently expended by this encumbrance';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_initial_amount IS 'The initial amount of this encumbrance. Should not change once create';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_order_type IS 'Taken from the purchase order';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_subscription IS 'Taken from the purchase Order,for fiscal year rollover';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_status IS 'The status of this encumbrance';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.po_line_id IS 'UUID referencing the poLine that represents the package that this POLs title belongs to';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.po_id IS 'UUID identifying this purchase order line';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.pol_number IS 'A human readable number assigned to this PO line';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.pol_description IS 'purchase order line description';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.pol_acquisition_method IS 'UUID of the acquisition method for this purchase order line';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.po_order_type IS 'the purchase order type';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.po_vendor_id IS 'UUID of the vendor record';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.po_vendor_name IS 'The name of vendor';
 
 VACUUM ANALYZE finance_transaction_purchase_order;
 

--- a/sql/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql/derived_tables/finance_transaction_purchase_order.sql
@@ -1,11 +1,4 @@
 -- Create a derived table that joins purchase orders and po_lines fields to transactions for encumbranced cost reports in system currency
---
--- Tables included:
---    finance_transactions
---    finance_funds
---    finance_budget
---    po_lines
---    po_purchase_orders
 
 DROP TABLE IF EXISTS finance_transaction_purchase_order;
 

--- a/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
@@ -1,11 +1,4 @@
 -- Create a derived table that joins purchase orders and po_lines fields to transactions for encumbranced cost reports in system currency
---
--- Tables included:
---    finance_transactions
---    finance_funds
---    finance_budget
---    po_lines
---    po_purchase_orders
 
 DROP TABLE IF EXISTS finance_transaction_purchase_order;
 

--- a/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
+++ b/sql_metadb/derived_tables/finance_transaction_purchase_order.sql
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS finance_transaction_purchase_order;
-
 -- Create a derived table that joins purchase orders and po_lines fields to transactions for encumbranced cost reports in system currency
 --
 -- Tables included:
@@ -8,6 +6,9 @@ DROP TABLE IF EXISTS finance_transaction_purchase_order;
 --    finance_budget
 --    po_lines
 --    po_purchase_orders
+
+DROP TABLE IF EXISTS finance_transaction_purchase_order;
+
 CREATE TABLE finance_transaction_purchase_order AS
 SELECT
     ft.id AS transaction_id,
@@ -25,6 +26,7 @@ SELECT
     jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'initialAmountEncumbered')::numeric(19,4) AS transaction_encumbrance_initial_amount,
     jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'orderType') AS transaction_encumbrance_order_type,
     jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'subscription') AS transaction_encumbrance_subscription,
+    jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'status') AS transaction_encumbrance_status,
     jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePoLineId')::uuid AS po_line_id,
     jsonb_extract_path_text(ft.jsonb, 'encumbrance', 'sourcePurchaseOrderId')::uuid AS po_id,
     jsonb_extract_path_text(pol.jsonb, 'poLineNumber') AS pol_number,
@@ -73,6 +75,8 @@ CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_orde
 
 CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_subscription);
 
+CREATE INDEX ON finance_transaction_purchase_order (transaction_encumbrance_status);
+
 CREATE INDEX ON finance_transaction_purchase_order (po_line_id);
 
 CREATE INDEX ON finance_transaction_purchase_order (po_id);
@@ -118,6 +122,8 @@ COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_ini
 COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_order_type IS 'Taken from the purchase order';
 
 COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_subscription IS 'Taken from the purchase Order,for fiscal year rollover';
+
+COMMENT ON COLUMN finance_transaction_purchase_order.transaction_encumbrance_status IS 'The status of this encumbrance';
 
 COMMENT ON COLUMN finance_transaction_purchase_order.po_line_id IS 'UUID referencing the poLine that represents the package that this POLs title belongs to';
 


### PR DESCRIPTION
This bugfix adds the missing encumbrance status to derived table `finance_trancaction_purchase_order` which is essential for particular reporting needs. Fixes #640  
Because LDP1 version is also needed to be fixed missing comments have been copied as well.


```
All queries:
- [ ] Release notes added or updated in CHANGES.md
- [ ] Query runs without errors
- [ ] Query output is correct
- [ ] Query logic is clear and well documented
- [ ] Query is readable and properly indented with spaces (not tabs)
- [ ] Table and column names are in all-lowercase
- [ ] Quotation marks are used only where necessary

Report queries:
- [ ] Query has complete user documentation
    - [ ] Purpose of report
    - [ ] Sample output
    - [ ] Query instructions

Derived tables:
- [ ] Query begins with user documentation in comment lines
- [ ] File name is listed in `runlist.txt` after dependencies
- [ ] All columns have indexes
- [ ] Table is vacuumed and analyzed
```
