### PR TITLE
Move release matrix to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,25 @@ This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 
-## Introduction
+## Releases
+
+Each release of folio-analytics is tested with specific FOLIO
+releases:
+
+| FOLIO         | folio-analytics for LDP1 | folio-analytics for Metadb |
+| ------------- | :----------------------: | :------------------------: |
+| Kiwi          |            1.2           |                            |
+| Lotus         |            1.3           |            1.5             |
+| Morning Glory |            1.4           |                            |
+| Nolana        |            1.5           |                            |
+| Orchid        |            1.6           |                            |
+| Poppy         |            1.7           |                            |
+
+It may not be necessary to match the versions precisely, but doing so
+when possible will usually offer the highest degree of compatibility.
+
+
+## Overview
 
 This repository contains reports and other analytics developed for
 FOLIO and designed to run on the [Library Data
@@ -52,24 +70,6 @@ Consult the README.md file in the [report queries](sql/report_queries)
 folder for a query table of contents, and look for additional
 README.md files in the query folders to explain how to run the
 reports.
-
-
-## Releases
-
-Each release of folio-analytics is tested with specific FOLIO
-releases:
-
-| FOLIO         | folio-analytics for LDP1 | folio-analytics for Metadb |
-| ------------- | :----------------------: | :------------------------: |
-| Kiwi          |            1.2           |                            |
-| Lotus         |            1.3           |            1.5             |
-| Morning Glory |            1.4           |                            |
-| Nolana        |            1.5           |                            |
-| Orchid        |            1.6           |                            |
-| Poppy         |            1.7           |                            |
-
-It may not be necessary to match the versions precisely, but doing so
-when possible will usually offer the highest degree of compatibility.
 
 
 ## Branches


### PR DESCRIPTION
Users often ask compatibility questions that are answered by the release matrix.  This change makes it more visible.