### PR TITLE
Update link to migration info in sql_metadb/README.md

### DIFF
--- a/sql_metadb/README.md
+++ b/sql_metadb/README.md
@@ -1,5 +1,5 @@
 
 This directory contains SQL queries for FOLIO data in Metadb.
 
-See the [Notes on migrating FOLIO queries from LDP 1.x to Metadb](porting.md).
+See the [Notes on migrating FOLIO queries from LDP 1.x to Metadb](https://d1f3dtrg62pav.cloudfront.net/doc/#_migrating_from_ldp).
 


### PR DESCRIPTION
The porting.md file was removed in April with a commit message referencing the MetaDB documentation. This readme file was still pointing to the old porting.md file, so this updates the link to point to the MetaDB documentation.