### PR TITLE
ACQ/ERM - Port Rpt ERM-Inventory Costs Cluster to Metadb

### DIFF
--- a/sql_metadb/report_queries/erm/erm_inventory_cost/README.md
+++ b/sql_metadb/report_queries/erm/erm_inventory_cost/README.md
@@ -1,0 +1,29 @@
+# ERM Costs Reports
+
+## Purpose
+
+This report is to provide a dataset of invoice lines to summarize certain costs on the predefined filter for electronic resorces in the inventory. Filters were designed to customize this queries on local needs. Furthermore costs on invoice line level are exemplary divided by instance subjects and formats. Take in account that this might duplicate invoice lines and needed to be adjusted if summing up totals. 
+
+The costs relies on the amounts out of the transactions table in system currency. This data will only appear if an invoice status is 'Approved' or 'Paid'. 
+The preset on the invoice status filter therefore is 'Paid'.
+
+## Parameters
+
+The parameters in the table below can be set in the WITH clause to filter the report output.
+
+| parameter | description | examples |
+| --- | --- | --- |
+| invoice\_approval\_date | date invoice was approved | Set start\_date and end\_date in YYYY-MM-DD format. |
+| invoice_line_status | status of the invoices to show, which can be open, reviewed, approved, paid, or cancelled | 'Paid', 'Approved', 'Open' etc. |
+| po_line_order_format | the purchase order line format| 'Electronic Resource', 'Physical Resource', 'P/E Mix' etc. |
+| instance_subject | name of the instance subject | |
+| mode_of_issuance_name | mode of issuance, a categorization reflecting whether a resource is issued in one or more parts, the way it is updated, and whether its termination is predetermined or not | 'serial', 'integrating resource', 'single unit' etc. |
+| format_name | instance format whether it's from the RDA carrier term list of locally defined | 'computer -- online resource'  for electronic resources |
+| library_name | library name of the permanent location | |
+
+## Sample Output
+
+|po_line_id|invl_id|invl_status|po_line_payment_status|po_line_is_package|invoice_payment_date|po_line_order_format|po_line_phys_mat_type|po_line_er_mat_type|instance_mode_of_issuance_name|invl_adjustment_description|invl_adjustment_prorate|invl_adjustment_relationtototal|invl_adjustment_value|invl_sub_total|invl_total|inv_adj_prorate|inv_adj_relationtototal|transactions_inv_adj_total|transactions_invl_total|invl_total_incl_adj|instance_format_name|total_by_format|instance_subject|total_by_subject|
+|----------|-------|-----------|----------------------|------------------|---------------------|--------------------|---------------------|-------------------|-------------------|------------------------------|---------------------------|-----------------------|-------------------------------|---------------------|--------------|----------|---------------|-----------------------|-------------|----------|--------------------|---------------|----------------|----------------|
+|2f3a877a-5a2d-4a8d-a226-d7691d43f4f5|a89bae81-889d-429d-853a-e0cff4780f66|Paid|Pending|false|2021-01-14 13:45:04|Electronic Resource| | | |Fees|Not prorated|In addition to|5|15|20|Not prorated|In addition to|$1.75|$15.76|$17.51| | |Medicine|$17.51|
+|e0f063e8-36c2-4cc8-9086-cdaf1c05d161|c5426cea-e6b9-430a-af8d-0612e21f1565|Paid|Pending|false|2021-01-12 11:42:24|Electronic Resource| | | | | | | |15|15| | | |$15.00|$15.00| | | |

--- a/sql_metadb/report_queries/erm/erm_inventory_cost/erm_inventory_cost.sql
+++ b/sql_metadb/report_queries/erm/erm_inventory_cost/erm_inventory_cost.sql
@@ -1,0 +1,166 @@
+/* 
+ * This report is to provide a dataset of invoice lines to summarize certain costs 
+ * on the predefined filter for electronic resorces in the inventory.
+ */ 
+
+WITH parameters AS (
+    SELECT
+        -- filters on invoice level
+        -- Please comment/uncomment one pair the these parameters if you want to define the date range of paid invoices
+        NULL :: DATE AS start_date,
+        NULL :: DATE AS end_date,
+        --'2021-01-01' :: DATE AS start_date, -- start date day is included in interval
+        --'2022-01-01' :: DATE AS end_date, -- end date day is NOT included in interval -> enter next day
+        --
+        -- filters on invoice line level
+        'Paid' :: VARCHAR AS invoice_line_status, -- Enter your invoice line status eg. 'Paid' or 'Approved'etc.
+        --
+        -- filters on purchase order line level
+        '' :: VARCHAR AS po_line_order_format, -- Enter your po line format eg. 'Electronic Resource', 'Physical Resource', 'P/E Mix' etc.
+        --
+        -- filters on instance level
+        '' :: VARCHAR AS instance_subject, -- Enter your  eg. 'Public welfare', 'Internet and children', 'Medicare'  etc.
+        '' :: VARCHAR AS mode_of_issuance_name, -- Enter your mode_of_issuance_name eg. 'integrating resource', 'serial', 'multipart monograph' etc.
+        'computer -- online resource' :: VARCHAR AS format_name, -- Enter your format_name eg. 'computer -- online resource'  etc.
+        '' :: VARCHAR AS library_name -- Enter your library_location_name eg. 'Datalogisk Institut','Adelaide Library' etc.
+),
+instance_detail AS (
+    SELECT
+        inst.instance_id AS instance_id,
+        inst.mode_of_issuance_name AS instance_mode_of_issuance_name,
+        inst_formats.instance_format_name AS instance_format_name,
+        inst_subjects.subjects AS instance_subject,
+        loc.library_name AS instance_library_name
+    FROM
+        folio_derived.instance_ext AS inst
+        LEFT JOIN folio_derived.instance_formats AS inst_formats ON inst.instance_id = inst_formats.instance_id
+        LEFT JOIN folio_derived.instance_subjects AS inst_subjects ON inst.instance_id = inst_subjects.instance_id
+        LEFT JOIN folio_derived.holdings_ext AS hld ON inst.instance_id = hld.instance_id
+        LEFT JOIN folio_derived.locations_libraries AS loc ON hld.permanent_location_id = loc.location_id
+),
+-- bringing in no of subjects per instance for further calculations
+instance_subs AS (
+    SELECT
+        subs.instance_id AS instance_id,
+        COUNT(DISTINCT subs.subjects) :: INTEGER AS no_instance_subjects
+    FROM
+        folio_derived.instance_subjects AS subs
+    GROUP BY
+        subs.instance_id
+),
+-- bringing in no of formats per instance for further calculations
+instance_formats AS (
+    SELECT
+        forms.instance_id AS instance_id,
+        COUNT(DISTINCT forms.instance_format_name) :: INTEGER AS no_instance_formats
+    FROM
+        folio_derived.instance_formats AS forms
+    GROUP BY
+        forms.instance_id
+),
+invoice_detail AS (
+    SELECT
+        inv.id AS invoice_id,
+        inv.payment_date AS invoice_payment_date
+    FROM
+        folio_invoice.invoices__t AS inv
+)
+SELECT
+    invl.po_line_id,
+    invl.id AS invl_id,
+    invl.invoice_line_status AS invl_status,
+    pol.payment_status AS po_line_payment_status,
+    pol.is_package AS po_line_is_package,
+    inv.invoice_payment_date AS invoice_payment_date,
+    pol.order_format AS po_line_order_format,
+    pol_phys_type.pol_mat_type_name AS po_line_phys_mat_type,
+    pol_er_type.pol_er_mat_type_name AS po_line_er_mat_type,
+    inst.instance_mode_of_issuance_name,
+    invl_adjustments.adjustment_description AS invl_adjustment_description,
+    invl_adjustments.adjustment_prorate AS invl_adjustment_prorate,
+    invl_adjustments.adjustment_relation_to_total AS invl_adjustment_relationtototal,
+    invl_adjustments.adjustment_value AS invl_adjustment_value,
+    invl_adjustments.adjustment_type AS invl_adjustment_type,
+    invl.sub_total AS invl_sub_total,
+    invl.total AS invl_total, -- this are costs by invoice_line in invoice currency
+    inv_adj.inv_adj_prorate,
+    inv_adj.inv_adj_relationtototal,
+    inv_adj.transactions_inv_adj_total :: NUMERIC(19,4), -- this are adjustments in system currency on invoice level 
+    fintrainvl.transaction_amount :: NUMERIC(19,4) AS transactions_invl_total,
+    SUM(inv_adj.transactions_inv_adj_total + fintrainvl.transaction_amount) :: NUMERIC(19,4) AS invl_total_incl_adj, -- this are costs in system currency by invoice_line including adjustments on invoice level
+    inst.instance_format_name,
+    CASE WHEN instform.no_instance_formats = 0 
+        THEN
+            NULL
+        ELSE
+            SUM( (fintrainvl.transaction_amount + COALESCE(inv_adj.transactions_inv_adj_total, 0)) / instform.no_instance_formats ) :: NUMERIC(19,4)
+    END AS total_by_format, -- this are costs by invoice_line prorated to the number of given formats including adjustments on invoice level
+    inst.instance_subject,
+    CASE WHEN instsub.no_instance_subjects = 0 
+        THEN
+            NULL
+        ELSE
+            SUM( (fintrainvl.transaction_amount + COALESCE(inv_adj.transactions_inv_adj_total, 0)) / instsub.no_instance_subjects ) :: NUMERIC(19,4)
+    END AS total_by_subject -- this are costs by invoice_line prorated to the number of given subjects including adjustments on invoice level
+FROM
+    folio_invoice.invoice_lines__t AS invl
+    LEFT JOIN invoice_detail AS inv ON invl.invoice_id = inv.invoice_id
+    LEFT JOIN folio_derived.invoice_adjustments_ext AS inv_adj ON inv_adj.invl_id = invl.id
+    LEFT JOIN folio_derived.finance_transaction_invoices AS fintrainvl ON fintrainvl.invoice_line_id = invl.id
+    LEFT JOIN folio_orders.po_line__t AS pol ON invl.po_line_id = pol.id
+    LEFT JOIN instance_detail AS inst ON pol.instance_id = inst.instance_id
+    LEFT JOIN folio_derived.po_lines_phys_mat_type AS pol_phys_type ON pol.instance_id = pol_phys_type.pol_id
+    LEFT JOIN folio_derived.po_lines_er_mat_type AS pol_er_type ON pol.instance_id = pol_er_type.pol_id
+    LEFT JOIN folio_derived.invoice_lines_adjustments AS invl_adjustments ON invl.id = invl_adjustments.invoice_line_id
+    LEFT JOIN instance_subs AS instsub ON instsub.instance_id = inst.instance_id
+    LEFT JOIN instance_formats AS instform ON instform.instance_id = inst.instance_id
+WHERE
+    ((inv.invoice_payment_date >= (SELECT start_date FROM parameters) AND 
+      inv.invoice_payment_date < (SELECT end_date FROM parameters))
+        OR 
+		(((SELECT start_date FROM parameters) IS NULL) OR 
+         ((SELECT end_date FROM parameters) IS NULL)))
+    AND 	
+    ((invl.invoice_line_status = (SELECT invoice_line_status FROM parameters)) OR 
+    ((SELECT invoice_line_status FROM parameters) = ''))
+    AND 	
+    ((pol.order_format = (SELECT po_line_order_format FROM parameters)) OR 
+    ((SELECT po_line_order_format FROM parameters) = ''))	
+    AND 	
+    ((inst.instance_format_name = (SELECT format_name FROM parameters)) OR 
+    ((SELECT format_name FROM parameters) = ''))		
+    AND 	
+    ((inst.instance_subject = (SELECT instance_subject FROM parameters)) OR 
+    ((SELECT instance_subject FROM parameters) = ''))	
+    AND 	
+    ((inst.instance_mode_of_issuance_name = (SELECT mode_of_issuance_name FROM parameters)) OR 
+    ((SELECT mode_of_issuance_name FROM parameters) = ''))	
+    AND 	
+    ((inst.instance_library_name = (SELECT library_name FROM parameters)) OR 
+    ((SELECT library_name FROM parameters) = ''))	
+GROUP BY 
+    invl.po_line_id,
+    invl.id,
+    invl.invoice_line_status,
+    pol.payment_status,
+    pol.is_package,
+    inv.invoice_payment_date,
+    pol.order_format,
+    pol_phys_type.pol_mat_type_name,
+    pol_er_type.pol_er_mat_type_name,
+    inst.instance_mode_of_issuance_name,
+    invl_adjustments.adjustment_description,
+    invl_adjustments.adjustment_prorate,
+    invl_adjustments.adjustment_relation_to_total,
+    invl_adjustments.adjustment_value,
+    invl_adjustments.adjustment_type,
+    invl.sub_total,
+    invl.total,
+    inv_adj.inv_adj_prorate,
+    inv_adj.inv_adj_relationtototal,
+    inv_adj.transactions_inv_adj_total,
+    inst.instance_format_name, 
+    instform.no_instance_formats, 
+    inst.instance_subject, 
+    instsub.no_instance_subjects,
+    fintrainvl.transaction_amount;


### PR DESCRIPTION
Closes #747 

Ported report from LDP1 to Metadb. The name of the subdirectory has been slightly changed to LDP1 version to avoid confusion with the report for agreements.

LDP1 version:
https://github.com/folio-org/folio-analytics/blob/main/sql/report_queries/erm/costs/erm_inventory_cost.sql