### PR TITLE
Fix po_lines columns in ldp_add_column.conf

### DIFF
--- a/sql/require_columns/ldp_add_column.conf
+++ b/sql/require_columns/ldp_add_column.conf
@@ -59,12 +59,13 @@ invoice_vouchers.type varchar
 invoice_vouchers.vendor_id varchar
 invoice_vouchers.voucher_date timestamptz
 invoice_vouchers.voucher_number varchar
-po_lines.cost__fyro_adjustment_amount
-po_lines.eresource__resource_url
-po_lines.instance_id
-po_lines.metadata__created_by_user_id
-po_lines.metadata__updated_by_user_id
-po_lines.physical__expected_receipt_date
-po_lines.receipt_date
+po_lines.cost__fyro_adjustment_amount numeric(12,2)
+po_lines.eresource__resource_url varchar
+po_lines.instance_id varchar
+po_lines.metadata__created_by_user_id varchar
+po_lines.metadata__updated_by_user_id varchar
+po_lines.physical__expected_receipt_date timestamptz
+po_lines.receipt_date timestamptz
+po_lines.selector varchar
 po_purchase_orders.po_number varchar
 po_purchase_orders.vendor varchar


### PR DESCRIPTION
This is for the derived tables for LDP1. Add missing datatypes for columns. Also add required column po_lines.selector (required by po_instance table build code). Resolves #749.