### PR TITLE
ERM - Report 'eusage_counter_rpt_ir' for Metadb

### DIFF
--- a/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/README.md
+++ b/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/README.md
@@ -1,0 +1,66 @@
+# COUNTER Item Master Report
+
+## Purpose
+
+This report is a A Standard View of COUNTER Item Master Reports and shows activity across all metrics for single items, such as articles or videos. The reports contains also additonal informations to the COUNTER report file.
+
+## Attributes
+
+| attribute | description | sample output |
+| --- | --- | --- |
+| id | UUID of the report | e034f768-5a29-4751-9212-3702ebddf4c5 |
+| report_name | Name of the report | Platform Master Report |
+| report_id | Identifier of the report | IR |
+| release | The version of COUNTER | 5 |
+| institution_name | Name of the institution to which usage is attributed | WIB1234 - Library XY |
+| institution_id | Identifier for the institution to which usage is attributed | 123456 |
+| reporting_period_start | Date range start covered by the report | 2023-04-01 |
+| reporting_period_end | Date range end covered by the report | 2023-04-30 |
+| created | Date the report was run | 2023-05-22 |
+| created_by | Name of organization or system that generated the report | Example LLC. |
+| report_year_mounth | Month and its year covered in the report. It is kind of a date range | 2023-04 |
+| Item | The title of the item | 3D Printed Microfluidics |
+| Publisher | An organization whose function is to commission, create, collect, validate, host, distribute and trade information online and\/or in printed form. | Annual Reviews |
+| Publisher_ID | An ID for the publisher | ar:1015 |
+| Platform | The name of the platform | Annual Reviews | 
+| Authors | The authors of the item | Alan Poland, Joyce C. Knutson |
+| Publication_Date | The publication date of the item | 2015-03-20 |
+| Article_Version | Defined by ALPSP and NISO as a classification of the version of an Article as it goes through its publication life-cycle. <br> * Accepted Manuscript (AM) <br> * Version of Record (VoR) <br> * Corrected Version of Record (CVoR) <br> * Enhanced Version of Record (EVoR) | VoR |
+| DOI | The digital object identifier for the item  | 10.1729/jhik.345 |
+| Proprietary | A COUNTER report item identifier for a unique identifier given by publishers and other content providers to a product or collection of products. | SampleIR:100026 |
+| Online_ISSN | The E-ISSN of the item | 1234-5678 |
+| Print_ISSN | The P-ISSN of the item | 1234-5678 |
+| ISBN | The ISBN of the item | 978-3-16-448410-7 |
+| URI | The URI of the item | http:\/\/www.example.com\/questions\/3456\/my-document |
+| Parent_Title | The parent title of the publication an item is part of. For a journal article, the parent is the journal, and for a book chapter it is the book. | Annual Review of Pharmacology and Toxicology |
+| Parent_Authors | The contributers \/ authors of the parent title an item is part of. For a journal article, the parent is the journal, and for a book chapter it is the book. | Alan Poland, Joyce C. Knutson |
+| Parent_Publication_Date | The publication date of the parent title | 2014-03-03 |
+| Parent_Article_Version | Defined by ALPSP and NISO as a classification of the version of an Article as it goes through its publication life-cycle. <br> * Accepted Manuscript (AM) <br> * Version of Record (VoR) <br> * Corrected Version of Record (CVoR) <br> * Enhanced Version of Record (EVoR) | VoR |
+| Parent_Data_Type | The element identifying the type of content. | Journal |
+| Data_Type | The element identifying the type of content. | Article |
+| YOP | Year of publication. Calendar year in which an article, item, issue, or volume is published. | 2015 |
+| Access_Type | A COUNTER report attribute used to report on the nature of access control restrictions, if any, placed on the content item at the time when the content item was accessed. <br> * Controlled <br> * OA_Gold <br> * OA_Delayed <br> * Other_Free_to_Read | OA_Gold |
+| Access_Method | This tells how the content was used. Regular means the usage was by a person, while TDM means robotic use | Regular |
+| Total_Item_Requests | A COUNTER Metric_Type that represents the number of times users requested the full content (e.g. a full text) of an item. Requests may take the form of viewing, downloading, emailing, or printing content, provided such actions can be tracked by the content provider. | 1|
+| Total_Item_Investigations | A COUNTER Metric_Type that represents the number of times users accessed the content (e.g. a full text) of an item, or information describing that item (e.g. an abstract). | 1 |
+| Unique_Item_Requests | A COUNTER Metric_Type that represents the number of unique content items requested in a user session. Examples of content items are articles, books, book chapters, and multimedia files. | 1 |
+| Unique_Item_Investigations | A COUNTER Metric_Type that represents the number of unique content items investigated in a user session. Examples of content items are articles, books, book chapters, and multimedia files. | 1 |
+| Parent_DOI | The digital object identifier for the parent title | 10.1729/jhik | 
+| Parent_Proprietary | A COUNTER report item identifier for a unique identifier given by publishers and other content providers to a product or collection of products. | SampleIR:45 | 
+| Parent_Online_ISSN | The E-ISSN of the parent title | 1234-5678 |
+| Parent_Print_ISSN | The P-ISSN of the parent title | 1234-5678 |
+| Parent_ISBN | The ISBN of the parent title | 978-3-16-458401-2 |
+| Parent_URI | The URI of the parent title | http:\/\/www.example.com\/questions\/3456\/my-document |
+
+## Parameters
+
+The parameters in the table below can be set in the WITH clause to filter the report output.
+
+| parameter | description | examples |
+| --- | --- | --- |
+| reporting_start_period | Start date of period of the COUNTER report | Set start date in YYYY-MM-DD format |
+| reporting_end_period |  End date of period of the COUNTER report | Set end date in YYYY-MM-DD format |
+| item_title | Filter out a specific item title | 3D Printed Microfluidics |
+| parent_title | Filter out a specific parent title | Annual Review of Pharmacology and Toxicology |
+| platform | Filter out a specific platform | Annual Reviews |
+| access_type | Filter out the nature of access control restrictions | * Controlled <br> * OA_Gold <br> * OA_Delayed <br> * Other_Free_to_Read | 

--- a/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/README.md
+++ b/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/README.md
@@ -9,7 +9,7 @@ This report is a A Standard View of COUNTER Item Master Reports and shows activi
 | attribute | description | sample output |
 | --- | --- | --- |
 | id | UUID of the report | e034f768-5a29-4751-9212-3702ebddf4c5 |
-| report_name | Name of the report | Platform Master Report |
+| report_name | Name of the report | Item Master Report |
 | report_id | Identifier of the report | IR |
 | release | The version of COUNTER | 5 |
 | institution_name | Name of the institution to which usage is attributed | WIB1234 - Library XY |

--- a/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/eusage_counter_rpt_ir.sql
+++ b/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_ir/eusage_counter_rpt_ir.sql
@@ -1,0 +1,261 @@
+/*
+ * COUNTER Item Master Report
+ * 
+ * This report is a A Standard View of COUNTER Item Master Reports and 
+ * shows activity across all metrics for single items, such as articles or videos. 
+ * The reports contains also additonal informations to the report file.
+ */
+
+WITH parameters AS (
+    SELECT
+        --'2022-01-01' :: DATE AS reporting_start_period,
+        --'2022-12-31' :: DATE AS reporting_end_period,
+        '' :: VARCHAR AS item_title, -- The title of an item, e.g. 'AI in Measurement Science' (Article level)
+        '' :: VARCHAR AS parent_title, -- The parent title of the item, e.g. 'Annual Review of Biochemistry' (Journal level)
+        '' :: VARCHAR AS platform, -- The name of the platform, e.g. 'Annual Reviews' (Provider level)
+        '' :: VARCHAR AS access_type -- The access type, e.g. Controlled, OA_Gold
+),
+counter_reports AS (
+    SELECT 
+        counter_reports.id,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Report_Name') AS report_name,
+        jsonb_extract_path_text(counter_reports.jsonb, 'reportName') AS report_id,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Release') AS release,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Institution_Name') AS institution_name,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Customer_ID') AS institution_id,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Period', 'Begin_Date') :: DATE AS reporting_period_start,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Period', 'End_Date') :: DATE AS reporting_period_end,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Created')::DATE AS created,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Created_By') AS created_by,
+        jsonb_extract_path_text(counter_reports.jsonb, 'yearMonth') AS report_year_mounth,              
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item') AS item,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher') AS publisher,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher_ID')->0, 'Type') AS publisher_id_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher_ID')->0, 'Value') AS publisher_id_value_1,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Platform') AS platform,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Contributors')->0, 'Type') AS item_contributors_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Contributors')->0, 'Name') AS item_contributors_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Dates')->0, 'Type') AS item_dates_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Dates')->0, 'Value') AS item_dates_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Attributes')->0, 'Type') AS item_attributes_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Attributes')->0, 'Value') AS item_attributes_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->0, 'Type') AS item_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->0, 'Value') AS item_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->1, 'Type') AS item_type_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->1, 'Value') AS item_value_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->2, 'Type') AS item_type_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->2, 'Value') AS item_value_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->3, 'Type') AS item_type_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->3, 'Value') AS item_value_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->4, 'Type') AS item_type_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->4, 'Value') AS item_value_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->5, 'Type') AS item_type_6,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->5, 'Value') AS item_value_6,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_Name') AS parent_title,
+        NULL AS parent_authors,
+        NULL AS parent_publication_date,
+        NULL AS parent_article_version,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Data_Type') AS parent_data_type,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->0, 'Type') AS parent_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->0, 'Value') AS parent_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->1, 'Type') AS parent_type_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->1, 'Value') AS parent_value_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->2, 'Type') AS parent_type_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->2, 'Value') AS parent_value_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->3, 'Type') AS parent_type_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->3, 'Value') AS parent_value_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->4, 'Type') AS parent_type_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->4, 'Value') AS parent_value_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->5, 'Type') AS parent_type_6,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_Parent', 'Item_ID')->5, 'Value') AS parent_value_6,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Data_Type') AS data_type,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'YOP') AS yop,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Access_Type') AS access_type,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Access_Method') AS access_method,           
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->0, 'Metric_Type') AS metric_type_1, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->0, 'Count')::INTEGER AS reporting_period_total_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->1, 'Metric_Type') AS metric_type_2, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->1, 'Count')::INTEGER AS reporting_period_total_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->2, 'Metric_Type') AS metric_type_3, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->2, 'Count')::INTEGER AS reporting_period_total_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->3, 'Metric_Type') AS metric_type_4, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->3, 'Count')::INTEGER AS reporting_period_total_4
+    FROM 
+        folio_erm_usage.counter_reports
+    WHERE 
+        jsonb_extract_path_text(counter_reports.jsonb, 'reportName') = 'IR'
+    ORDER BY
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item'),
+        jsonb_extract_path_text(counter_reports.jsonb, 'yearMonth') DESC
+)
+SELECT 
+    counter_reports.id,
+    counter_reports.report_name,
+    counter_reports.report_id,
+    counter_reports.release,
+    counter_reports.institution_name,
+    counter_reports.institution_id,
+    counter_reports.reporting_period_start,
+    counter_reports.reporting_period_end,
+    counter_reports.created,
+    counter_reports.created_by,
+    counter_reports.report_year_mounth,
+    counter_reports.item,
+    counter_reports.publisher,
+    CASE 
+        WHEN counter_reports.publisher_id_type_1 = 'Proprietary' THEN counter_reports.publisher_id_value_1
+    END AS publisher_id,        
+    counter_reports.platform,
+    CASE 
+        WHEN counter_reports.item_contributors_type_1 = 'Author' THEN counter_reports.item_contributors_value_1
+    END AS authors,        
+    CASE 
+        WHEN counter_reports.item_dates_type_1 = 'Publication_Date' THEN counter_reports.item_dates_value_1 
+    END AS publication_date,        
+    CASE 
+        WHEN counter_reports.item_attributes_type_1 = 'Article_Version' THEN counter_reports.item_attributes_value_1
+    END AS article_version,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'DOI' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'DOI' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'DOI' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'DOI' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'DOI' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'DOI' THEN counter_reports.item_value_6
+    END AS doi,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'Proprietary' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'Proprietary' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'Proprietary' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'Proprietary' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'Proprietary' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'Proprietary' THEN counter_reports.item_value_6
+    END AS proprietary,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'Online_ISSN' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'Online_ISSN' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'Online_ISSN' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'Online_ISSN' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'Online_ISSN' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'Online_ISSN' THEN counter_reports.item_value_6
+    END AS online_issn,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'Print_ISSN' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'Print_ISSN' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'Print_ISSN' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'Print_ISSN' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'Print_ISSN' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'Print_ISSN' THEN counter_reports.item_value_6
+    END AS print_issn,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'ISBN' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'ISBN' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'ISBN' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'ISBN' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'ISBN' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'ISBN' THEN counter_reports.item_value_6
+    END AS isbn,
+    CASE 
+        WHEN counter_reports.item_type_1 = 'URI' THEN counter_reports.item_value_1
+        WHEN counter_reports.item_type_2 = 'URI' THEN counter_reports.item_value_2
+        WHEN counter_reports.item_type_3 = 'URI' THEN counter_reports.item_value_3
+        WHEN counter_reports.item_type_4 = 'URI' THEN counter_reports.item_value_4
+        WHEN counter_reports.item_type_5 = 'URI' THEN counter_reports.item_value_5
+        WHEN counter_reports.item_type_6 = 'URI' THEN counter_reports.item_value_6
+    END AS uri,
+    counter_reports.parent_title,
+    counter_reports.parent_authors,
+    counter_reports.parent_publication_date,
+    counter_reports.parent_article_version,
+    counter_reports.parent_data_type,    
+    counter_reports.data_type,
+    counter_reports.yop,
+    counter_reports.access_type,
+    counter_reports.access_method,
+    CASE
+        WHEN counter_reports.metric_type_1 = 'Total_Item_Requests' THEN counter_reports.reporting_period_total_1 
+        WHEN counter_reports.metric_type_2 = 'Total_Item_Requests' THEN counter_reports.reporting_period_total_2
+        WHEN counter_reports.metric_type_3 = 'Total_Item_Requests' THEN counter_reports.reporting_period_total_3
+        WHEN counter_reports.metric_type_4 = 'Total_Item_Requests' THEN counter_reports.reporting_period_total_4
+    END AS total_item_requests,
+    CASE
+        WHEN counter_reports.metric_type_1 = 'Total_Item_Investigations' THEN counter_reports.reporting_period_total_1 
+        WHEN counter_reports.metric_type_2 = 'Total_Item_Investigations' THEN counter_reports.reporting_period_total_2
+        WHEN counter_reports.metric_type_3 = 'Total_Item_Investigations' THEN counter_reports.reporting_period_total_3
+        WHEN counter_reports.metric_type_4 = 'Total_Item_Investigations' THEN counter_reports.reporting_period_total_4
+    END AS total_item_investigations,
+    CASE
+        WHEN counter_reports.metric_type_1 = 'Unique_Item_Requests' THEN counter_reports.reporting_period_total_1 
+        WHEN counter_reports.metric_type_2 = 'Unique_Item_Requests' THEN counter_reports.reporting_period_total_2
+        WHEN counter_reports.metric_type_3 = 'Unique_Item_Requests' THEN counter_reports.reporting_period_total_3
+        WHEN counter_reports.metric_type_4 = 'Unique_Item_Requests' THEN counter_reports.reporting_period_total_4
+    END AS unique_item_requests,
+    CASE
+        WHEN counter_reports.metric_type_1 = 'Unique_Item_Investigations' THEN counter_reports.reporting_period_total_1 
+        WHEN counter_reports.metric_type_2 = 'Unique_Item_Investigations' THEN counter_reports.reporting_period_total_2
+        WHEN counter_reports.metric_type_3 = 'Unique_Item_Investigations' THEN counter_reports.reporting_period_total_3
+        WHEN counter_reports.metric_type_4 = 'Unique_Item_Investigations' THEN counter_reports.reporting_period_total_4
+    END AS unique_item_investigations,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'DOI' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'DOI' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'DOI' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'DOI' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'DOI' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'DOI' THEN counter_reports.parent_value_6
+    END AS parent_doi,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'Proprietary' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'Proprietary' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'Proprietary' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'Proprietary' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'Proprietary' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'Proprietary' THEN counter_reports.parent_value_6
+    END AS parent_proprietary,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'Online_ISSN' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'Online_ISSN' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'Online_ISSN' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'Online_ISSN' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'Online_ISSN' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'Online_ISSN' THEN counter_reports.parent_value_6
+    END AS parent_online_issn,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'Print_ISSN' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'Print_ISSN' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'Print_ISSN' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'Print_ISSN' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'Print_ISSN' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'Print_ISSN' THEN counter_reports.parent_value_6
+    END AS parent_print_issn,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'ISBN' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'ISBN' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'ISBN' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'ISBN' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'ISBN' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'ISBN' THEN counter_reports.parent_value_6
+    END AS parent_isbn,
+    CASE 
+        WHEN counter_reports.parent_type_1 = 'URI' THEN counter_reports.parent_value_1
+        WHEN counter_reports.parent_type_2 = 'URI' THEN counter_reports.parent_value_2
+        WHEN counter_reports.parent_type_3 = 'URI' THEN counter_reports.parent_value_3
+        WHEN counter_reports.parent_type_4 = 'URI' THEN counter_reports.parent_value_4
+        WHEN counter_reports.parent_type_5 = 'URI' THEN counter_reports.parent_value_5
+        WHEN counter_reports.parent_type_6 = 'URI' THEN counter_reports.parent_value_6
+    END AS parent_uri
+FROM 
+    counter_reports
+WHERE 
+    ((counter_reports.item = (SELECT item_title FROM parameters)) OR ((SELECT item_title FROM parameters) = ''))
+    AND 
+    ((counter_reports.parent_title = (SELECT parent_title FROM parameters)) OR ((SELECT parent_title FROM parameters) = ''))
+    AND 
+    ((counter_reports.platform = (SELECT platform FROM parameters)) OR ((SELECT platform FROM parameters) = ''))
+    AND 
+    ((counter_reports.access_type = (SELECT access_type FROM parameters)) OR ((SELECT access_type FROM parameters) = ''))
+    /*AND 
+    counter_reports.reporting_period_start >= (SELECT reporting_start_period FROM parameters)
+    AND 
+    counter_reports.reporting_period_end <= (SELECT reporting_end_period FROM parameters) */
+;


### PR DESCRIPTION
Closes #768 
This report is intended to contain data from the FOLIO app eUsage. In this case, the report contains only data for Item Master Reports (IR). The required attributes can be found at https://medialibrary.projectcounter.org/file/The-Friendly-Guide-for-Librarians . In addition to this attributes there are attributes to the downloaded COUNTER report.

For performance reasons, the arrays are read based on positions.