### PR TITLE
ERM - Report 'eusage_counter_rpt_tr' for Metadb

### DIFF
--- a/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_tr/README.md
+++ b/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_tr/README.md
@@ -1,0 +1,50 @@
+# COUNTER Title Master Report
+
+## Purpose
+
+This report is a standard view of COUNTER Title Master Reports and shows activity across all metrics for entire titles, which may be ebooks or journal titles. The reports contains also additonal informations to the COUNTER report file.
+
+## Attributes
+
+| attribute | description | sample output |
+| --- | --- | --- |
+| id | UUID of the report | e034f768-5a29-4751-9212-3702ebddf4c5 |
+| report_name | Name of the report | Title Master Report |
+| report_id | Identifier of the report | TR |
+| release | The version of COUNTER | 5 |
+| institution_name | Name of the institution to which usage is attributed | WIB1234 - Library XY |
+| institution_id | Identifier for the institution to which usage is attributed | 123456 |
+| reporting_period_start | Date range start covered by the report | 2023-04-01 |
+| reporting_period_end | Date range end covered by the report | 2023-04-30 |
+| created | Date the report was run | 2023-05-22 |
+| created_by | Name of organization or system that generated the report | Example LLC. |
+| report_year_mounth | Month and its year covered in the report. It is kind of a date range | 2023-04 |
+| title | | |
+| publisher | An organization whose function is to commission, create, collect, validate, host, distribute and trade information online and\/or in printed form. | Annual Reviews |
+| publisher_id | An ID for the publisher | ar:1015 |
+| platform | The name of the platform | Annual Reviews |
+| proprietary_id | A COUNTER report item identifier for a unique identifier given by publishers and other content providers to a product or collection of products | ar:anchem |
+| eissn | The Online ISSN of the title | 1936-1335 |
+| data_type | The element identifying the type of content. | Journal |
+| section_type | A COUNTER report attribute that identifies the type of section that was accessed by the user | Article |
+| yop | Year of publication. Calendar year in which an article, item, issue, or volume is published. | 2015 |
+| access_type | A COUNTER report attribute used to report on the nature of access control restrictions, if any, placed on the content item at the time when the content item was accessed. <br> * Controlled <br> * OA_Gold <br> * OA_Delayed <br> * Other_Free_to_Read | Controlled |
+| access_method | This tells how the content was used. Regular means the usage was by a person, while TDM means robotic use | Regular |
+| unique_item_requests | A COUNTER Metric_Type that represents the number of unique content items requested in a user session. Examples of content items are articles, books, book chapters, and multimedia files. | 1 |
+| unique_item_investigations | A COUNTER Metric_Type that represents the number of unique content items investigated in a user session. Examples of content items are articles, books, book chapters, and multimedia files. | 1 |
+| total_item_requests | A COUNTER Metric_Type that represents the number of times users requested the full content (e.g. a full text) of an item. Requests may take the form of viewing, downloading, emailing, or printing content, provided such actions can be tracked by the content provider. | 1 |
+| total_item_investigations | A COUNTER Metric_Type that represents the number of times users accessed the content (e.g. a full text) of an item, or information describing that item (e.g. an abstract). | 1 |
+| no_license | A COUNTER Metric_Type. A user is denied access to a content item because the user or the user’s institution does not have access rights under an agreement with the vendor | 1 |
+
+## Parameters
+
+The parameters in the table below can be set in the WITH clause to filter the report output.
+
+| parameter | description | examples |
+| --- | --- | --- |
+| reporting_start_period | Start date of period of the COUNTER report | Set start date in YYYY-MM-DD format |
+| reporting_end_period |  End date of period of the COUNTER report | Set end date in YYYY-MM-DD format |
+| title | Filter out a specific title | Annual Review of Cell and Developmental Biology |
+| yop | Filter out a specific year where the publications were published | 2021 |
+| publisher | Filter out a specific publisher | Annual Reviews |
+| platform | Filter out a specific platform | Annual Reviews |

--- a/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_tr/eusage_counter_rpt_tr.sql
+++ b/sql_metadb/report_queries/erm/eusage_counter_reports/eusage_counter_rpt_tr/eusage_counter_rpt_tr.sql
@@ -1,0 +1,161 @@
+/*
+ * COUNTER Title Master Report
+ * 
+ * This report is a standard view of COUNTER Title Master Reports and 
+ * shows activity across all metrics for entire titles, which may be 
+ * ebooks or journal titles. The reports contains also additonal 
+ * informations to the COUNTER report file.
+ */
+
+WITH parameters AS (
+    SELECT
+        --'2022-01-01' :: DATE AS reporting_start_period,
+        --'2022-12-31' :: DATE AS reporting_end_period,
+        '' :: VARCHAR AS title, -- The name of the title, e.g. Annual Review of Cell and Developmental Biology
+        '' :: VARCHAR AS yop, -- The year of publication, e.g. 2021
+        '' :: VARCHAR AS publisher, -- The name of the publisher, e.g. Annual Reviews
+        '' :: VARCHAR AS platform -- The name of the platform, e.g. Annual Reviews
+),
+counter_reports AS (
+    SELECT 
+        counter_reports.id,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Report_Name') AS report_name,
+        jsonb_extract_path_text(counter_reports.jsonb, 'reportName') AS report_id,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Release') AS release,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Institution_Name') AS institution_name,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Customer_ID') AS institution_id,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Period', 'Begin_Date')::DATE AS reporting_period_start,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Period', 'End_Date')::DATE AS reporting_period_end,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Created')::DATE AS created,
+        jsonb_extract_path_text(counter_reports.jsonb, 'report', 'Report_Header', 'Created_By') AS created_by,
+        jsonb_extract_path_text(counter_reports.jsonb, 'yearMonth') AS report_year_mounth,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Title') AS title,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher') AS publisher,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher_ID')->0, 'Type') AS publisher_id_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Publisher_ID')->0, 'Value') AS publisher_id_value_1,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Platform') AS platform,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->0, 'Type') AS item_type_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->0, 'Value') AS item_value_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->1, 'Type') AS item_type_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->1, 'Value') AS item_value_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->2, 'Type') AS item_type_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->2, 'Value') AS item_value_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->3, 'Type') AS item_type_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->3, 'Value') AS item_value_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->4, 'Type') AS item_type_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->4, 'Value') AS item_value_5,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->5, 'Type') AS item_type_6,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Item_ID')->5, 'Value') AS item_value_6,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Data_Type') AS data_type,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Section_Type') AS section_type,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'YOP') AS yop,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Access_Type') AS access_type,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Access_Method') AS access_method,        
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->0, 'Metric_Type') AS metric_type_1, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->0, 'Count')::INTEGER AS reporting_period_total_1,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->1, 'Metric_Type') AS metric_type_2, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->1, 'Count')::INTEGER AS reporting_period_total_2,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->2, 'Metric_Type') AS metric_type_3, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->2, 'Count')::INTEGER AS reporting_period_total_3,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->3, 'Metric_Type') AS metric_type_4, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->3, 'Count')::INTEGER AS reporting_period_total_4,
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->4, 'Metric_Type') AS metric_type_5, 
+        jsonb_extract_path_text(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Performance')), 'Instance')->4, 'Count')::INTEGER AS reporting_period_total_5
+    FROM 
+        folio_erm_usage.counter_reports
+    WHERE 
+        jsonb_extract_path_text(counter_reports.jsonb, 'reportName') = 'TR'
+    ORDER BY 
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'Title'),
+        jsonb_extract_path_text(counter_reports.jsonb, 'yearMonth') DESC,
+        jsonb_extract_path_text(jsonb_array_elements(jsonb_extract_path(counter_reports.jsonb, 'report', 'Report_Items')), 'YOP') DESC
+)
+SELECT 
+    counter_reports.id,
+    counter_reports.report_name,
+    counter_reports.report_id,
+    counter_reports.release,
+    counter_reports.institution_name,
+    counter_reports.institution_id,
+    counter_reports.reporting_period_start,
+    counter_reports.reporting_period_end,
+    counter_reports.created,
+    counter_reports.created_by,
+    counter_reports.report_year_mounth,
+    counter_reports.title,
+    counter_reports.publisher,
+    CASE 
+        WHEN counter_reports.publisher_id_type_1 = 'Proprietary' THEN publisher_id_value_1
+    END AS publisher_id,
+    counter_reports.platform,
+    CASE 
+        WHEN item_type_1 = 'Proprietary' THEN item_value_1
+        WHEN item_type_2 = 'Proprietary' THEN item_value_2
+        WHEN item_type_3 = 'Proprietary' THEN item_value_3
+        WHEN item_type_4 = 'Proprietary' THEN item_value_4
+        WHEN item_type_5 = 'Proprietary' THEN item_value_5
+        WHEN item_type_6 = 'Proprietary' THEN item_value_6
+    END AS proprietary_id,
+    CASE 
+        WHEN item_type_1 = 'Online_ISSN' THEN item_value_1
+        WHEN item_type_2 = 'Online_ISSN' THEN item_value_2
+        WHEN item_type_3 = 'Online_ISSN' THEN item_value_3
+        WHEN item_type_4 = 'Online_ISSN' THEN item_value_4
+        WHEN item_type_5 = 'Online_ISSN' THEN item_value_5
+        WHEN item_type_6 = 'Online_ISSN' THEN item_value_6
+    END AS eissn,
+    counter_reports.data_type,
+    counter_reports.section_type,
+    counter_reports.yop,
+    counter_reports.access_type,
+    counter_reports.access_method,
+    CASE 
+        WHEN metric_type_1 = 'Unique_Item_Requests' THEN reporting_period_total_1
+        WHEN metric_type_2 = 'Unique_Item_Requests' THEN reporting_period_total_2
+        WHEN metric_type_3 = 'Unique_Item_Requests' THEN reporting_period_total_3
+        WHEN metric_type_4 = 'Unique_Item_Requests' THEN reporting_period_total_4
+        WHEN metric_type_5 = 'Unique_Item_Requests' THEN reporting_period_total_5
+    END AS unique_item_requests,
+    CASE 
+        WHEN metric_type_1 = 'Unique_Item_Investigations' THEN reporting_period_total_1
+        WHEN metric_type_2 = 'Unique_Item_Investigations' THEN reporting_period_total_2
+        WHEN metric_type_3 = 'Unique_Item_Investigations' THEN reporting_period_total_3
+        WHEN metric_type_4 = 'Unique_Item_Investigations' THEN reporting_period_total_4
+        WHEN metric_type_5 = 'Unique_Item_Investigations' THEN reporting_period_total_5
+    END AS unique_item_investigations,
+    CASE 
+        WHEN metric_type_1 = 'Total_Item_Requests' THEN reporting_period_total_1
+        WHEN metric_type_2 = 'Total_Item_Requests' THEN reporting_period_total_2
+        WHEN metric_type_3 = 'Total_Item_Requests' THEN reporting_period_total_3
+        WHEN metric_type_4 = 'Total_Item_Requests' THEN reporting_period_total_4
+        WHEN metric_type_5 = 'Total_Item_Requests' THEN reporting_period_total_5
+    END AS total_item_requests,
+    CASE 
+        WHEN metric_type_1 = 'Total_Item_Investigations' THEN reporting_period_total_1
+        WHEN metric_type_2 = 'Total_Item_Investigations' THEN reporting_period_total_2
+        WHEN metric_type_3 = 'Total_Item_Investigations' THEN reporting_period_total_3
+        WHEN metric_type_4 = 'Total_Item_Investigations' THEN reporting_period_total_4
+        WHEN metric_type_5 = 'Total_Item_Investigations' THEN reporting_period_total_5
+    END AS total_item_investigations,
+    CASE 
+        WHEN metric_type_1 = 'No_License' THEN reporting_period_total_1
+        WHEN metric_type_2 = 'No_License' THEN reporting_period_total_2
+        WHEN metric_type_3 = 'No_License' THEN reporting_period_total_3
+        WHEN metric_type_4 = 'No_License' THEN reporting_period_total_4
+        WHEN metric_type_5 = 'No_License' THEN reporting_period_total_5
+    END AS no_license
+FROM 
+    counter_reports
+WHERE 
+    ((counter_reports.title = (SELECT title FROM parameters)) OR ((SELECT title FROM parameters) = ''))
+    AND 
+    ((counter_reports.yop = (SELECT yop FROM parameters)) OR ((SELECT yop FROM parameters) = ''))
+    AND 
+    ((counter_reports.publisher = (SELECT publisher FROM parameters)) OR ((SELECT publisher FROM parameters) = ''))
+    AND 
+    ((counter_reports.platform = (SELECT platform FROM parameters)) OR ((SELECT platform FROM parameters) = ''))
+    /*AND 
+    counter_reports.reporting_period_start >= (SELECT reporting_start_period FROM parameters)
+    AND 
+    counter_reports.reporting_period_end <= (SELECT reporting_end_period FROM parameters)*/
+;


### PR DESCRIPTION
Closes #767 
This report is intended to contain data from the FOLIO app eUsage. In this case, the report contains only data for Title Master Reports (TR). The required attributes can be found at https://medialibrary.projectcounter.org/file/The-Friendly-Guide-for-Librarians . In addition to this attributes there are attributes to the downloaded COUNTER report.

For performance reasons, the arrays are read based on positions.