### PR TITLE
ACQ - updated metadb table name to match LDP table name - po_lines_vendor_reference_numbers

### DIFF
--- a/sql_metadb/derived_tables/po_lines_vendor_reference_numbers.sql
+++ b/sql_metadb/derived_tables/po_lines_vendor_reference_numbers.sql
@@ -1,4 +1,4 @@
---metadb:table po_line_vendor_reference_number
+--metadb:table po_lines_vendor_reference_numbers
 
 -- This derived table extracts reference numbers from po_lines vendor
 -- details.

--- a/sql_metadb/derived_tables/po_lines_vendor_reference_numbers.sql
+++ b/sql_metadb/derived_tables/po_lines_vendor_reference_numbers.sql
@@ -3,9 +3,9 @@
 -- This derived table extracts reference numbers from po_lines vendor
 -- details.
 
-DROP TABLE IF EXISTS po_line_vendor_reference_number;
+DROP TABLE IF EXISTS po_lines_vendor_reference_numbers;
 
-CREATE TABLE po_line_vendor_reference_number AS 
+CREATE TABLE po_lines_vendor_reference_numbers AS 
 SELECT
     pl.id AS po_line_id,
     plt.po_line_number AS po_line_number,
@@ -17,13 +17,13 @@ FROM folio_orders.po_line AS pl
         AS numbers (jsonb)
     LEFT JOIN folio_orders.po_line__t plt ON pl.id = plt.id;
 
-COMMENT ON COLUMN po_line_vendor_reference_number.po_line_id IS 'UUID identifying this purchase order line';
+COMMENT ON COLUMN po_lines_vendor_reference_numbers.po_line_id IS 'UUID identifying this purchase order line';
 
-COMMENT ON COLUMN po_line_vendor_reference_number.po_line_number IS 'A human readable number assigned to this PO line';
+COMMENT ON COLUMN po_lines_vendor_reference_numbers.po_line_number IS 'A human readable number assigned to this PO line';
 
-COMMENT ON COLUMN po_line_vendor_reference_number.vendor_reference_number IS 'A reference number for this purchase order line';
+COMMENT ON COLUMN po_lines_vendor_reference_numbers.vendor_reference_number IS 'A reference number for this purchase order line';
 
-COMMENT ON COLUMN po_line_vendor_reference_number.vendor_reference_number_type IS 'The reference number type';
+COMMENT ON COLUMN po_lines_vendor_reference_numbers.vendor_reference_number_type IS 'The reference number type';
 
-COMMENT ON COLUMN po_line_vendor_reference_number.vendor_instructions IS 'Special instructions for the vendor';
+COMMENT ON COLUMN po_lines_vendor_reference_numbers.vendor_instructions IS 'Special instructions for the vendor';
 

--- a/sql_metadb/derived_tables/runlist.txt
+++ b/sql_metadb/derived_tables/runlist.txt
@@ -48,7 +48,7 @@ po_acq_unit_ids.sql
 po_instance.sql
 po_lines_cost.sql
 po_line_fund_distribution_transactions.sql
-po_line_vendor_reference_number.sql
+po_lines_vendor_reference_numbers.sql
 po_lines_details_subscription.sql
 po_lines_er_mat_type.sql
 po_lines_eresource.sql


### PR DESCRIPTION
Closes #757

Updated filename for "po_line_vendor_reference_number" to "po_lines_vendor_reference_numbers" to match equivalent LDP table name. 
Also updated entry for "po_line_vendor_reference_number" to "po_lines_vendor_reference_numbers" in runlist.txt file for metadb. 
Also updated  "--metadb:table po_line_vendor_reference_number" to "--metadb:table po_lines_vendor_reference_numbers" at top of query.

Documented this update on the 1.7 (Poppy) release notes at https://github.com/folio-org/folio-analytics/wiki/Changes-by-Release