### PR TITLE
Update loans_renewal_dates.sql for LDP

### DIFF
--- a/sql/derived_tables/loans_renewal_dates.sql
+++ b/sql/derived_tables/loans_renewal_dates.sql
@@ -1,22 +1,43 @@
-/* This derived table pulls renewals from the circulation_loan_history by 
- * filtering on the loan's "action" column. Additional columns allow users to 
- * join renewals with dates to other tables, to filter down to specific renewals, 
- * or to validate the results. */
+/*This derived table captures the renewal actions from the public.circulation_loan_history table and shows the dates of renewal. 
+ The table also captures the current loan status from the public.circulation_loans table. 
+ This table may be used to count the number of renewals within a given renewal date range, or count the number of renewals 
+ for specific loans. */
+
+	
 DROP TABLE IF EXISTS loans_renewal_dates;
 
 CREATE TABLE loans_renewal_dates AS
-    SELECT
-        id AS loan_history_id,
-        created_date AS loan_action_date,
-        (data #>> '{loan,id}')::uuid AS loan_id,
-        (data #>> '{loan,itemId}')::uuid AS item_id,
-        data #>> '{loan,action}' AS loan_action,
-        data #>> '{loan,renewalCount}' AS loan_renewal_count,
-        data #>> '{loan,status,name}' AS loan_status
-    FROM public.circulation_loan_history
-    WHERE
-        (data #>> '{loan,action}') IN ('renewed', 'renewedThroughOverride')
-    ORDER BY
-        loan_id,
-        loan_action_date;
 
+SELECT     
+        clh.loan__id AS loan_id,
+        clh.loan__loan_date AS loan_date,
+        clh.loan__item_id AS item_id,
+        invitems.hrid AS item_hrid,
+        clh.loan__actiON AS loan_action,
+        DATE_TRUNC ('minute', clh.created_date::TIMESTAMPTZ) AS renewal_date,
+        COUNT (DISTINCT clh.loan__id) AS folio_renewal_count,   
+        cl.status__name AS loan_status
+        
+    FROM public.circulation_loan_history AS clh
+	    LEFT JOIN public.circulation_loans AS cl 
+	    ON clh.loan__id::UUID = cl.id::UUID	   
+	    
+	    LEFT JOIN inventory_items AS invitems 
+	    ON clh.loan__item_id::UUID = invitems.id::UUID
+    
+    WHERE
+        clh.loan__action IN ('renewed', 'renewedThroughOverride')
+        
+    GROUP BY         
+        clh.loan__id,
+        clh.loan__loan_date,
+        clh.loan__item_id,
+        invitems.hrid,
+        clh.loan__action,
+        DATE_TRUNC ('minute', clh.created_date::TIMESTAMPTZ),
+        cl.status__name
+        
+    ORDER BY
+        clh.loan__id,
+        DATE_TRUNC ('minute', clh.created_date::TIMESTAMPTZ) asc
+        ;


### PR DESCRIPTION
-- Changes to query: 
	-- truncated the renewal date ("created date") to 'minutes' to eliminate renewals seconds apart, which are artifacts of system processes, not actual patron renewals.
	-- added the item hrid
	-- selected the loan status from the circulation_loans table, not the circulation_loan_history table (which always shows "Open" for renewals)
	-- removed the loan history id ("id") from Select statement, since including it would make it impossible group by loan_id and count renewals
	-- removed the "loan_renewal_count" field (selected from the circulation_loan_history table) to prevent misuse of the field in calculating total renewals over a date range.