### PR TITLE
Update loans_renewal_dates.sql derived table for Metadb

### DIFF
--- a/sql_metadb/derived_tables/loans_renewal_dates.sql
+++ b/sql_metadb/derived_tables/loans_renewal_dates.sql
@@ -1,31 +1,53 @@
---metadb:table loans_renewal_dates
+--metadb:table loans_renewal_dates 
 
-/* This derived table pulls renewals from the folio_circulation.loan table by 
- * filtering on the loan's "action" column. Additional columns allow users to 
- * join renewals with dates to other tables, to filter down to specific renewals, 
- * or to validate the results. */
+/*This derived table captures the renewal actions from the folio_circulation.audit_loan table and shows the dates of renewal. 
+ The table also captures the current loan status from the folio_circulation.loan table. 
+ This table may be used to count the number of renewals within a given renewal date range, or count the number of renewals 
+ for specific loans. The folio_renewal_count is the number of times the loan has been renewed in FOLIO. */
+ 
 DROP TABLE IF EXISTS loans_renewal_dates;
 
---check for rows that are duplicated except for __id
 CREATE TABLE loans_renewal_dates AS
-    WITH distinct_records AS (
-        SELECT
-            DISTINCT __start, id, jsonb
-        FROM
-            folio_circulation.loan
-    )
-    SELECT
-        --__id AS loan_history_id, -- can add back in if we stop de-duplicating rows
-        __start AS loan_action_date,
-        id AS loan_id,
-        jsonb_extract_path_text(jsonb, 'itemId') AS item_id,
-        jsonb_extract_path_text(jsonb, 'action') AS loan_action,
-        jsonb_extract_path_text(jsonb, 'renewalCount') AS loan_renewal_count,
-        jsonb_extract_path_text(jsonb, 'status', 'name') AS loan_status
-    FROM distinct_records
-    WHERE
-        jsonb_extract_path_text(jsonb, 'action') IN ('renewed', 'renewedThroughOverride')
-    ORDER BY
-        loan_id,
-        loan_action_date;
 
+SELECT DISTINCT
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','id') AS loan_id,
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','loanDate')::TIMESTAMPTZ AS loan_date,
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','itemId') AS item_id,
+        item__t.hrid AS item_hrid,
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','action') AS loan_action,
+        DATE_TRUNC ('minute',jsonb_extract_path_text(audit_loan.jsonb, 'loan','metadata','updatedDate')::TIMESTAMPTZ) AS renewal_date, -- truncated to eliminate seconds
+        COUNT (DISTINCT jsonb_extract_path_text(audit_loan.jsonb, 'loan','id')) AS folio_renewal_count,       
+        jsonb_extract_path_text(loan.jsonb, 'status','name') AS loan_status
+
+    FROM folio_circulation.audit_loan
+    	LEFT JOIN folio_circulation.loan 
+    	ON jsonb_extract_path_text(audit_loan.jsonb, 'loan','id')::UUID = loan.id::UUID
+    	
+    	LEFT JOIN folio_inventory.item__t 
+    	ON jsonb_extract_path_text(audit_loan.jsonb, 'loan','itemId')::UUID = item__t.id::UUID
+    	
+    WHERE
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','action') IN ('renewed', 'renewedThroughOverride')       
+
+	GROUP BY 
+		jsonb_extract_path_text(audit_loan.jsonb, 'loan','id'),
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','loanDate')::TIMESTAMPTZ,
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','itemId'),
+        item__t.hrid,
+        jsonb_extract_path_text(audit_loan.jsonb, 'loan','action'),
+        DATE_TRUNC ('minute',jsonb_extract_path_text(audit_loan.jsonb, 'loan','metadata','updatedDate')::TIMESTAMPTZ), -- truncated to eliminate seconds
+		jsonb_extract_path_text(loan.jsonb, 'status','name')
+		
+    ORDER by
+    	jsonb_extract_path_text(audit_loan.jsonb, 'loan','id'),
+    	date_trunc('minute',jsonb_extract_path_text(audit_loan.jsonb, 'loan','metadata','updatedDate')::TIMESTAMPTZ)
+    	;
+    	
+    COMMENT ON COLUMN loans_renewal_dates.loan_id IS 'The ID of the loan';
+    COMMENT ON COLUMN loans_renewal_dates.item_id IS 'The ID of the item';
+    COMMENT ON COLUMN loans_renewal_dates.item_hrid IS 'The HRID of the loan';
+    COMMENT ON COLUMN loans_renewal_dates.loan_action IS 'Last action performed on a loan (currently can be any value, values commonly used are checkedout and checkedin)';
+    COMMENT ON COLUMN loans_renewal_dates.renewal_date IS 'Date of renewal of the loan';
+    COMMENT ON COLUMN loans_renewal_dates.folio_renewal_count IS 'Number of times the loan was renewed in FOLIO';
+    COMMENT ON COLUMN loans_renewal_dates.loan_status IS 'Name of the status of the loan (currently can be any value, values commonly used are Open and Closed)';
+    


### PR DESCRIPTION
This PR closes issue#854

This is a revision of the loans_renewal_dates derived table in LDP. -- This uses the circulation_loan_history table for the data source; this table has been significantly changed since the derived table was originally created -- Changes to query: 
	-- truncated the renewal date ("created date") to 'minutes' to eliminate renewals seconds apart, which are artifacts of system processes, not actual patron renewals.
	-- added the item hrid
	-- selected the loan status from the circulation_loans table, not the circulation_loan_history table (which always shows "Open" for renewals)
	-- removed the loan history id ("id") from Select statement, since including it would make it impossible group by loan_id and count renewals
	-- removed the "loan_renewal_count" field (selected from the circulation_loan_history table) to prevent misuse of the field in calculating total renewals over a date range.